### PR TITLE
TRA-3299 Reduce footprint

### DIFF
--- a/cli/kubernetes/provider.go
+++ b/cli/kubernetes/provider.go
@@ -269,6 +269,13 @@ func (provider *Provider) ApplyMizuTapperDaemonSet(ctx context.Context, namespac
 	affinity := applyconfcore.Affinity()
 	affinity.WithNodeAffinity(nodeAffinity)
 
+	noExecuteToleration := applyconfcore.Toleration()
+	noExecuteToleration.WithOperator(core.TolerationOpExists)
+	noExecuteToleration.WithEffect(core.TaintEffectNoExecute)
+	noScheduleToleration := applyconfcore.Toleration()
+	noScheduleToleration.WithOperator(core.TolerationOpExists)
+	noScheduleToleration.WithEffect(core.TaintEffectNoSchedule)
+
 	podSpec := applyconfcore.PodSpec()
 	podSpec.WithHostNetwork(true)
 	podSpec.WithDNSPolicy(core.DNSClusterFirstWithHostNet)
@@ -278,6 +285,7 @@ func (provider *Provider) ApplyMizuTapperDaemonSet(ctx context.Context, namespac
 	}
 	podSpec.WithContainers(agentContainer)
 	podSpec.WithAffinity(affinity)
+	podSpec.WithTolerations(noExecuteToleration, noScheduleToleration)
 
 	podTemplate := applyconfcore.PodTemplateSpec()
 	podTemplate.WithLabels(map[string]string{"app": tapperPodName})


### PR DESCRIPTION
Reduced footprint:
Only put tapper pods on nodes which have pods that we should tap.
Implemented with a node affinity to a list of node names.
CLI already knows the node names prior to this PR.

Robustness to taints:
Added "joker" tolerations to tapper pods. Will ignore "NoExecute" and "NoSchedule" taints. Without this change, tappers might not be allowed to start on tainted nodes, this preventing us from recording them.