### PR TITLE
Fix expanded button color

### DIFF
--- a/ui/src/components/EntryDetailed/EntrySections.module.sass
+++ b/ui/src/components/EntryDetailed/EntrySections.module.sass
@@ -16,13 +16,12 @@
     line-height: 0.92
     margin-right: .5rem
     font-weight: 800
-    color: $blue-color
+    color: $main-background-color
     background-color: $light-blue-color
     &.expanded
         @extend .button
         line-height: .75rem
         background-color: $blue-color
-        color: $main-background-color
 
 .dataLine
     font-weight: 600


### PR DESCRIPTION
Fixes the color issue in expanded buttons. (-/+ sign before "Details")

### Before

![Screenshot from 2021-10-12 11-02-02](https://user-images.githubusercontent.com/2502080/136916436-c78eba02-7df3-46a2-8365-6cfbb7777e44.png)

### After

![Screenshot from 2021-10-12 10-58-57](https://user-images.githubusercontent.com/2502080/136916458-4368572d-ffc9-4f48-8d8a-73f2b57a002d.png)