### PR TITLE
feat: add goreleaser config for creating automatically homebrew formula

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,3 +202,29 @@ jobs:
           tag: ${{ steps.versioning.outputs.version }}
           prerelease: ${{ github.ref != 'refs/heads/main' }}
           bodyFile: 'cli/bin/README.md'
+  
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: Fetch all tags
+        run: git fetch --force --tags
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: ${{ env.GITHUB_REF_NAME }}
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.PUBLISHER_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,10 @@
+brews:
+  -
+    name: kubeshark
+    homepage: https://github.com/kubeshark/kubeshark
+    tap:
+      owner: kubeshark
+      name: homebrew-kubeshark
+    commit_author:
+      name: atileren
+      email: atil.eren@outlook.com


### PR DESCRIPTION
this pr was created for generating the homebrew formula automatically via goreleaser. We should add PUBLISHER_TOKEN secret to kubeshark repository. This token is personal access token and needs content permission on kubeshark and homebrew-kubeshark repository. Also, we need change commit_author information on goreleaser config. goreleaser uses this information when it commits formula to homebrew-kubeshark repository.