### PR TITLE
Upgrade deprecated set-output GitHub Actions syntax to avoid warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,11 @@ jobs:
         id: version
         shell: bash
         run: |
-          echo "##[set-output name=tag;]$(echo ${GITHUB_REF#refs/*/})"
-          echo "##[set-output name=build_timestamp;]$(echo $(date +%s))"
-          echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+          {
+            echo "tag=${GITHUB_REF#refs/*/}"
+            echo "build_timestamp=$(date +%s)"
+            echo "branch=${GITHUB_REF#refs/heads/}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Build
         run: make build-all VER='${{ steps.version.outputs.tag }}' BUILD_TIMESTAMP='${{ steps.version.outputs.build_timestamp }}'
@@ -61,9 +63,11 @@ jobs:
         id: version
         shell: bash
         run: |
-          echo "##[set-output name=tag;]$(echo ${GITHUB_REF#refs/*/})"
-          echo "##[set-output name=build_timestamp;]$(echo $(date +%s))"
-          echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+          {
+            echo "tag=${GITHUB_REF#refs/*/}"
+            echo "build_timestamp=$(date +%s)"
+            echo "branch=${GITHUB_REF#refs/heads/}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Fetch all tags
         run: git fetch --force --tags


### PR DESCRIPTION
The current `set-output` syntax being used is deprecated and will be disabled on 2023-05-31 due to security concerns. See [GitHub Actions: Deprecating save-state and set-output commands | GitHub Changelog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) for details. 

This change cleans up the syntax a bit and will get rid of the warning messages in the GitHub Actions logs.