### PR TITLE
Upgrade github actions versions to latest and update deprecated options

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -16,16 +16,18 @@ jobs:
     name: Golint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
-      - uses: actions/setup-go@v2
+      - name: Set up Go
+        uses: actions/setup-go@v4
         with:
-          go-version: '^1.17'
+          go-version-file: 'go.mod'
 
       - name: Go lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: latest
           args: --timeout=10m

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,13 @@ jobs:
     name: Build and publish a new release
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.17
-        uses: actions/setup-go@v2
+      - name: Set up Go
+        uses: actions/setup-go@v4
         with:
-          go-version: '1.17'
+          go-version-file: 'go.mod'
 
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Version
         id: version
@@ -55,7 +55,7 @@ jobs:
     needs: [release]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -73,16 +73,16 @@ jobs:
         run: git fetch --force --tags
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.17
+          go-version-file: 'go.mod'
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+        uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser
           version: ${{ env.GITHUB_REF_NAME }}
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
           VER: ${{ steps.version.outputs.tag }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,17 +15,17 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 2
 
-      - name: Set up Go 1.17
-        uses: actions/setup-go@v2
+      - name: Set up Go
+        uses: actions/setup-go@v4
         with:
-          go-version: '^1.17'
+          go-version-file: 'go.mod'
 
       - name: Test
         run: make test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3


### PR DESCRIPTION
This updates several GitHub Actions versions and uses latest syntax for options on them:

- Upgrade `actions/checkout` to latest (`v3`) to avoid node version warnings
- Upgrade `actions/setup-go` to latest (`v4`) and use `go.mod` as the single source of truth for the go version
- Upgrade `golangci/golangci-lint-action` to latest (`v3`)
- Upgrade `codecov/codecov-action` to latest (`v3`)
- Upgrade `goreleaser/goreleaser-action` to latest (`v4`) and use `--clean` instead of deprecated `--rm-dist` (see [notice](https://goreleaser.com/deprecations/#-rm-dist))

If this would be better as separate PRs, definitely let me know.