### PR TITLE
✨Allow to disable IPv6

### DIFF
--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -61,6 +61,7 @@ helm install kubeshark kubeshark/kubeshark \
   --set "tap.ingress.auth.approveddomains={gmail.com}" \
   --set license=LICENSE_GOES_HERE
 ```
+
 You can get your license [here](https://console.kubeshark.co/).
 
 ## Installing with Persistent Storage Enabled
@@ -70,4 +71,14 @@ helm install kubeshark kubeshark/kubeshark \
   --set tap.persistentstorage=true \
   --set license=LICENSE_GOES_HERE
 ```
+
 You can get your license [here](https://console.kubeshark.co/).
+
+## Disabling IPV6
+
+Not all have IPV6 enabled, hence this has to be disabled as follows:
+
+```shell
+helm install kubeshark kubeshark/kubeshark \
+  --set tap.ipv6=false
+```

--- a/helm-chart/templates/06-front-pod.yaml
+++ b/helm-chart/templates/06-front-pod.yaml
@@ -41,6 +41,15 @@ spec:
         requests:
           cpu: 50m
           memory: 50Mi
+      volumeMounts:
+        - name: nginx-config
+          mountPath: /etc/nginx/conf.d/default.conf
+          subPath: default.conf
+          readOnly: true
+  volumes:
+    - name: nginx-config
+      configMap:
+        name:  kubeshark-nginx-config
   dnsPolicy: ClusterFirstWithHostNet
   serviceAccountName: kubeshark-service-account
   terminationGracePeriodSeconds: 0

--- a/helm-chart/templates/12-nginx-config.yaml
+++ b/helm-chart/templates/12-nginx-config.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubeshark-nginx-config
+  namespace: {{ .Release.Namespace }}
+  apiVersion: v1
+data:
+  default.conf: |
+    server {
+      listen 80;
+{{- if .Values.tap.ipv6 }}
+      listen [::]:80;
+{{- end }}
+      add_header Cache-Control no-cache;
+      location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri $uri/ /index.html;
+        expires -1;
+      }
+      error_page   500 502 503 504  /50x.html;
+      location = /50x.html {
+        root   /usr/share/nginx/html;
+      }
+    }
+

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -56,6 +56,7 @@ tap:
       approveddomains: []
     certmanager: letsencrypt-prod
   debug: false
+  ipv6: true
 logs:
   file: ""
 kube:


### PR DESCRIPTION
I figured it would make sense to configure whether to use ipv6 or not. Currently - as we have not enabled ipv6 yet - I am unable to get kubeshark running