### PR TITLE
helm chart overhaul

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -22,5 +22,5 @@ name: kubeshark
 sources:
   - https://github.com/kubeshark/kubeshark/tree/master/helm-chart
 type: application
-version: "41.5"
+version: "42.0"
 icon: https://raw.githubusercontent.com/kubeshark/assets/master/logo/vector/logo.svg

--- a/helm-chart/templates/01-service-account.yaml
+++ b/helm-chart/templates/01-service-account.yaml
@@ -2,14 +2,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  creationTimestamp: null
+  {{- if .Values.rbac.labels }}
   labels:
-  {{- if .Values.tap.labels }}
-    {{- toYaml .Values.tap.labels | nindent 4 }}
+    {{- toYaml .Values.rbac.labels | nindent 4 }}
   {{- end }}
+  {{- if .Values.rbac.annotations }}
   annotations:
-  {{- if .Values.tap.annotations }}
-    {{- toYaml .Values.tap.annotations | nindent 4 }}
+    {{- toYaml .Values.rbac.annotations | nindent 4 }}
   {{- end }}
-  name: kubeshark-service-account
-  namespace: {{ .Release.Namespace }}
+  name:  {{ .Release.Name }}-service-account

--- a/helm-chart/templates/02-cluster-role.yaml
+++ b/helm-chart/templates/02-cluster-role.yaml
@@ -1,18 +1,17 @@
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
+  {{- if .Values.rbac.labels }}
   labels:
-  {{- if .Values.tap.labels }}
-    {{- toYaml .Values.tap.labels | nindent 4 }}
+    {{- toYaml .Values.rbac.labels | nindent 4 }}
   {{- end }}
+  {{- if .Values.rbac.annotations }}
   annotations:
-  {{- if .Values.tap.annotations }}
-    {{- toYaml .Values.tap.annotations | nindent 4 }}
+    {{- toYaml .Values.rbac.annotations | nindent 4 }}
   {{- end }}
-  name: kubeshark-cluster-role
-  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-cluster-role
 rules:
   - apiGroups:
       - ""

--- a/helm-chart/templates/03-cluster-role-binding.yaml
+++ b/helm-chart/templates/03-cluster-role-binding.yaml
@@ -3,21 +3,20 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
+  {{- if .Values.rbac.labels }}
   labels:
-  {{- if .Values.tap.labels }}
-    {{- toYaml .Values.tap.labels | nindent 4 }}
+    {{- toYaml .Values.rbac.labels | nindent 4 }}
   {{- end }}
+  {{- if .Values.rbac.annotations }}
   annotations:
-  {{- if .Values.tap.annotations }}
-    {{- toYaml .Values.tap.annotations | nindent 4 }}
+    {{- toYaml .Values.rbac.annotations | nindent 4 }}
   {{- end }}
-  name: kubeshark-cluster-role-binding
-  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-cluster-role-binding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kubeshark-cluster-role
+  name: {{ .Release.Name }}-cluster-role
 subjects:
   - kind: ServiceAccount
-    name: kubeshark-service-account
+    name: {{ .Release.Name }}-service-account
     namespace: {{ .Release.Namespace }}

--- a/helm-chart/templates/04-hub-pod.yaml
+++ b/helm-chart/templates/04-hub-pod.yaml
@@ -1,55 +1,64 @@
----
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     app: kubeshark-hub
-  {{- if .Values.tap.labels }}
-    {{- toYaml .Values.tap.labels | nindent 4 }}
-  {{- end }}
+    {{- if .Values.hub.labels }}
+    {{- toYaml .Values.hub.labels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.hub.annotations }}
   annotations:
-  {{- if .Values.tap.annotations }}
-    {{- toYaml .Values.tap.annotations | nindent 4 }}
+    {{- toYaml .Values.hub.annotations | nindent 4 }}
   {{- end }}
-  name: kubeshark-hub
-  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-hub  # Update the Deployment name to include the release name
 spec:
-  containers:
-    - command:
-        - ./hub
-        {{ .Values.tap.debug | ternary "- -debug" "" }}
-      env:
-        - name: POD_REGEX
-          value: '{{ .Values.tap.regex }}'
-        - name: NAMESPACES
-          value: '{{ gt (len .Values.tap.namespaces) 0 | ternary (join "," .Values.tap.namespaces) "" }}'
-        - name: LICENSE
-          value: '{{ .Values.license }}'
-        - name: SCRIPTING_ENV
-          value: '{{ .Values.scripting.env | toJson }}'
-        - name: SCRIPTING_SCRIPTS
-          value: '[]'
-        - name: AUTH_APPROVED_DOMAINS
-          value: '{{ gt (len .Values.tap.ingress.auth.approveddomains) 0 | ternary (join "," .Values.tap.ingress.auth.approveddomains) "" }}'
-      image: '{{ .Values.tap.docker.registry }}/hub:{{ .Values.tap.docker.tag }}'
-      imagePullPolicy: {{ .Values.tap.docker.imagepullpolicy }}
-      name: kubeshark-hub
-      resources:
-        limits:
-          cpu: {{ .Values.tap.resources.hub.limits.cpu }}
-          memory: {{ .Values.tap.resources.hub.limits.memory }}
-        requests:
-          cpu: {{ .Values.tap.resources.hub.requests.cpu }}
-          memory: {{ .Values.tap.resources.hub.requests.memory }}
-  dnsPolicy: ClusterFirstWithHostNet
-  serviceAccountName: kubeshark-service-account
-  terminationGracePeriodSeconds: 0
-  tolerations:
-    - effect: NoExecute
-      operator: Exists
-{{- if not .Values.tap.ignoretainted }}
-    - effect: NoSchedule
-      operator: Exists
-{{- end }}
-status: {}
+  replicas: {{ .Values.hub.replicas }}   # Use the replicas variable from the values file
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-hub
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-hub
+        {{- if .Values.hub.labels }}
+          {{ toYaml .Values.hub.labels | nindent 8 }}
+        {{- end }}
+      {{- if .Values.hub.annotations }}
+      annotations:
+        {{ toYaml .Values.hub.annotations | nindent 8 }}
+      {{- end }}
+    spec:
+      containers:
+        - command:
+            - ./hub
+            {{ .Values.hub.debug | ternary "- -debug" "" }}
+          env:
+            - name: POD_REGEX
+              value: '{{ .Values.tap.regex }}'
+            - name: NAMESPACES
+              value: '{{ gt (len .Values.tap.config.namespaces) 0 | ternary (join "," .Values.tap.namespaces) "" }}'
+            - name: LICENSE
+              value: '{{ .Values.license }}'
+            - name: SCRIPTING_ENV
+              value: '{{ .Values.scripting.env | toJson }}'
+            - name: SCRIPTING_SCRIPTS
+              value: '[]'
+            - name: AUTH_APPROVED_DOMAINS
+              value: '{{ gt (len .Values.ingress.auth.approveddomains) 0 | ternary (join "," .Values.ingress.auth.approveddomains) "" }}'
+          image: '{{ .Values.hub.image.registry }}/{{ .Values.hub.image.name }}:{{ .Values.hub.image.tag }}'
+          imagePullPolicy: {{ .Values.hub.imagepullpolicy }}
+          name: kubeshark-hub
+          ports:
+            - containerPort: 80   # Expose port 80 in the container
+              name: http-api
+          {{- if .Values.hub.resources }}
+          resources:
+            {{ toYaml .Values.hub.resources | nindent 12 }}
+          {{- end }}
+      {{- if .Values.hub.tolerations }}
+      tolerations:
+        {{ toYaml .Values.hub.tolerations | nindent 8 }}
+      {{- end }}
+      dnsPolicy: ClusterFirstWithHostNet
+      serviceAccountName: {{ .Release.Name }}-service-account
+      terminationGracePeriodSeconds: 0

--- a/helm-chart/templates/05-hub-service.yaml
+++ b/helm-chart/templates/05-hub-service.yaml
@@ -1,25 +1,20 @@
----
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
+  {{- if .Values.hub.service.labels }}
   labels:
-  {{- if .Values.tap.labels }}
-    {{- toYaml .Values.tap.labels | nindent 4 }}
+    {{ toYaml .Values.hub.service.labels | nindent 4 }}
   {{- end }}
+  {{- if .Values.hub.service.annotations }}
   annotations:
-  {{- if .Values.tap.annotations }}
-    {{- toYaml .Values.tap.annotations | nindent 4 }}
+    {{ toYaml .Values.hub.service.annotations | nindent 4 }}
   {{- end }}
-  name: kubeshark-hub
-  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-hub
 spec:
   ports:
-    - name: kubeshark-hub
-      port: 80
-      targetPort: 80
+    - name: http-api
+      port: {{ .Values.hub.service.port }}
+      targetPort: http-api
   selector:
-    app: kubeshark-hub
-  type: NodePort
-status:
-  loadBalancer: {}
+    app: {{ .Release.Name }}-hub
+  type: {{ .Values.hub.service.type }} 

--- a/helm-chart/templates/06-front-pod.yaml
+++ b/helm-chart/templates/06-front-pod.yaml
@@ -1,53 +1,62 @@
----
-apiVersion: v1
-kind: Pod
+apiVersion: apps/v1
+kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
-    app: kubeshark-front
-  {{- if .Values.tap.labels }}
-    {{- toYaml .Values.tap.labels | nindent 4 }}
+    app:  {{ .Release.Name }}-front
+  {{- if .Values.front.labels }}
+    {{- toYaml .Values.front.labels | nindent 4 }}
   {{- end }}
   annotations:
-  {{- if .Values.tap.annotations }}
-    {{- toYaml .Values.tap.annotations | nindent 4 }}
+  {{- if .Values.front.annotations }}
+    {{- toYaml .Values.front.annotations | nindent 4 }}
   {{- end }}
-  name: kubeshark-front
-  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-front  # Update the Deployment name to include the release name
 spec:
-  containers:
-    - env:
-        - name: REACT_APP_DEFAULT_FILTER
-          value: ' '
-        - name: REACT_APP_HUB_HOST
-          value: ' '
-        - name: REACT_APP_HUB_PORT
-          value: '{{ .Values.tap.ingress.enabled | ternary "/api" (print ":" .Values.tap.proxy.hub.port) }}'
-      image: '{{ .Values.tap.docker.registry }}/front:{{ .Values.tap.docker.tag }}'
-      imagePullPolicy: {{ .Values.tap.docker.imagepullpolicy }}
-      name: kubeshark-front
-      readinessProbe:
-        failureThreshold: 3
-        periodSeconds: 1
-        successThreshold: 1
-        tcpSocket:
-          port: 80
-        timeoutSeconds: 1
-      resources:
-        limits:
-          cpu: 750m
-          memory: 1Gi
-        requests:
-          cpu: 50m
-          memory: 50Mi
-  dnsPolicy: ClusterFirstWithHostNet
-  serviceAccountName: kubeshark-service-account
-  terminationGracePeriodSeconds: 0
-  tolerations:
-    - effect: NoExecute
-      operator: Exists
-{{- if not .Values.tap.ignoretainted }}
-    - effect: NoSchedule
-      operator: Exists
+  replicas: {{ .Values.front.replicas }}   # Use the replicas variable from the values file
+  selector:
+    matchLabels:
+      app:  {{ .Release.Name }}-front
+  template:
+    metadata:
+      labels:
+        app:  {{ .Release.Name }}-front
+        {{- if .Values.front.labels }}
+{{ toYaml .Values.front.labels | nindent 8 }}
 {{- end }}
-status: {}
+      annotations:
+        {{- if .Values.front.annotations }}
+{{ toYaml .Values.front.annotations | nindent 8 }}
+{{- end }}
+    spec:
+      containers:
+        - env:
+            - name: REACT_APP_DEFAULT_FILTER
+              value: ' '
+            - name: REACT_APP_HUB_HOST
+              value: ' '
+            - name: REACT_APP_HUB_PORT
+              value: '{{ .Values.hub.service.port }}'   # Use the hubPort variable from the values file
+          image: '{{ .Values.front.image.registry }}/{{ .Values.front.image.name }}:{{ .Values.front.image.tag }}'  # Use the image variables from the values file
+          imagePullPolicy: {{ .Values.front.imagePullPolicy }}  # Use the imagePullPolicy variable from the values file
+          name: kubeshark-front
+          ports:
+            - containerPort: 80
+              name: http-frontend  # Expose port 80 in the container
+          readinessProbe:
+            failureThreshold: 3
+            periodSeconds: 1
+            successThreshold: 1
+            tcpSocket:
+              port: 80
+            timeoutSeconds: 1
+{{- if .Values.front.resources }}
+          resources:
+{{ toYaml .Values.front.resources | nindent 12 }}   # Use the resources variable from the values file
+{{- end }}
+{{- if .Values.front.tolerations }}
+      tolerations:
+{{ toYaml .Values.front.tolerations | nindent 8 }}   # Use the tolerations variable from the values file
+{{- end }}
+      dnsPolicy: ClusterFirstWithHostNet
+      serviceAccountName:  {{ .Release.Name }}-service-account
+      terminationGracePeriodSeconds: 0

--- a/helm-chart/templates/07-front-service.yaml
+++ b/helm-chart/templates/07-front-service.yaml
@@ -3,23 +3,20 @@ apiVersion: v1
 kind: Service
 metadata:
   creationTimestamp: null
+  {{- if .Values.front.service.labels }}
   labels:
-  {{- if .Values.tap.labels }}
-    {{- toYaml .Values.tap.labels | nindent 4 }}
+    {{ toYaml .Values.front.service.labels | nindent 4 }}   # Use labels from .Values.front.service
   {{- end }}
+  {{- if .Values.front.service.annotations }}
   annotations:
-  {{- if .Values.tap.annotations }}
-    {{- toYaml .Values.tap.annotations | nindent 4 }}
+    {{ toYaml .Values.front.service.annotations | nindent 4 }}   # Use annotations from .Values.front.service
   {{- end }}
-  name: kubeshark-front
-  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-front # Update the Service name to include the release name
 spec:
   ports:
-    - name: kubeshark-front
-      port: 80
-      targetPort: 80
+    - name: http-frontend
+      port: {{ .Values.front.service.port }}   # Use the port variable from .Values.front.service
+      targetPort: http-frontend   # Keep the targetPort as 80, the container's static port
   selector:
-    app: kubeshark-front
-  type: NodePort
-status:
-  loadBalancer: {}
+    app: {{ .Release.Name }}-front
+  type: {{ .Values.front.service.type }}   # Use the service type variable from .Values.front.service

--- a/helm-chart/templates/08-persistent-volume-claim.yaml
+++ b/helm-chart/templates/08-persistent-volume-claim.yaml
@@ -3,17 +3,15 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  creationTimestamp: null
-  labels:
   {{- if .Values.tap.labels }}
+  labels:
     {{- toYaml .Values.tap.labels | nindent 4 }}
   {{- end }}
-  annotations:
   {{- if .Values.tap.annotations }}
+  annotations:
     {{- toYaml .Values.tap.annotations | nindent 4 }}
   {{- end }}
-  name: kubeshark-persistent-volume-claim
-  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-persistent-worker-tap
 spec:
   accessModes:
     - ReadWriteMany
@@ -21,5 +19,4 @@ spec:
     requests:
       storage: {{ .Values.tap.storagelimit }}
   storageClassName: {{ .Values.tap.storageclass }}
-status: {}
 {{- end }}

--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -1,36 +1,33 @@
----
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   creationTimestamp: null
   labels:
-    app: kubeshark-worker-daemon-set
-  {{- if .Values.tap.labels }}
+    app: {{ .Release.Name }}-worker-tap
+    {{- if .Values.tap.labels }}
     {{- toYaml .Values.tap.labels | nindent 4 }}
-  {{- end }}
-  annotations:
+    {{- end }}
   {{- if .Values.tap.annotations }}
+  annotations:
     {{- toYaml .Values.tap.annotations | nindent 4 }}
   {{- end }}
-  name: kubeshark-worker-daemon-set
-  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-worker-tap
 spec:
   selector:
     matchLabels:
-      app: kubeshark-worker-daemon-set
-    {{- if .Values.tap.labels }}
+      app: {{ .Release.Name }}-worker-tap
+      {{- if .Values.tap.labels }}
       {{- toYaml .Values.tap.labels | nindent 6 }}
-    {{- end }}
+      {{- end }}
   template:
     metadata:
       creationTimestamp: null
       labels:
-        app: kubeshark-worker-daemon-set
-      {{- if .Values.tap.labels }}
+        app: {{ .Release.Name }}-worker-tap
+        {{- if .Values.tap.labels }}
         {{- toYaml .Values.tap.labels | nindent 8 }}
-      {{- end }}
-      name: kubeshark-worker-daemon-set
-      namespace: kubeshark
+        {{- end }}
+      name: {{ .Release.Name }}-worker-tap
     spec:
       containers:
         - command:
@@ -38,22 +35,22 @@ spec:
             - -i
             - any
             - -port
-            - '{{ .Values.tap.proxy.worker.srvport }}'
+            - '{{ .Values.tap.port }}'
             - -servicemesh
             - -tls
             - -procfs
             - /hostproc
-            {{ .Values.tap.debug | ternary "- -debug" "" }}
-          image: '{{ .Values.tap.docker.registry }}/worker:{{ .Values.tap.docker.tag }}'
-          imagePullPolicy: {{ .Values.tap.docker.imagepullpolicy }}
-          name: kubeshark-worker-daemon-set
+            {{ .Values.tap.config.debug | ternary "- -debug" "" }}
+          image: '{{ .Values.tap.image.registry }}/{{ .Values.tap.image.name }}:{{ .Values.tap.image.tag }}'
+          imagePullPolicy: {{ .Values.tap.imagepullpolicy }}
+          name: kubeshark-worker-tap
+          ports:
+            - containerPort: {{ .Values.tap.port }}
+              name: tap
+          {{- if .Values.tap.resources }}
           resources:
-            limits:
-              cpu: {{ .Values.tap.resources.worker.limits.cpu }}
-              memory: {{ .Values.tap.resources.worker.limits.memory }}
-            requests:
-              cpu: {{ .Values.tap.resources.worker.requests.cpu }}
-              memory: {{ .Values.tap.resources.worker.requests.memory }}
+            {{ toYaml .Values.tap.resources | nindent 12 }}   # Use the resources variable from the values file
+          {{- end }}
           securityContext:
             capabilities:
               add:
@@ -72,28 +69,25 @@ spec:
             - mountPath: /sys
               name: sys
               readOnly: true
-{{- if .Values.tap.persistentstorage }}
+            {{- if .Values.tap.persistentstorage }}
             - mountPath: /app/data
-              name: kubeshark-persistent-volume
-{{- end }}
+              name: persistent-worker-data
+            {{- end }}
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
-      serviceAccountName: kubeshark-service-account
+      serviceAccountName: {{ .Release.Name }}-service-account
       terminationGracePeriodSeconds: 0
+      {{- if .Values.tap.tolerations }}
       tolerations:
-        - effect: NoExecute
-          operator: Exists
-{{- if not .Values.tap.ignoretainted }}
-        - effect: NoSchedule
-          operator: Exists
-{{- end }}
-{{- if gt (len .Values.tap.nodeselectorterms) 0}}
+        {{ toYaml .Values.tap.tolerations | nindent 8 }}   # Use the tolerations variable from the values file
+      {{- end }}
+      {{- if gt (len .Values.tap.nodeselectorterms) 0}}
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               {{- toYaml .Values.tap.nodeselectorterms | nindent 12 }}
-{{- end }}
+        {{- end }}
       volumes:
         - hostPath:
             path: /proc
@@ -101,8 +95,8 @@ spec:
         - hostPath:
             path: /sys
           name: sys
-{{- if .Values.tap.persistentstorage }}
-        - name: kubeshark-persistent-volume
+        {{- if .Values.tap.persistentstorage }}
+        - name: persistent-worker-data
           persistentVolumeClaim:
-            claimName: kubeshark-persistent-volume-claim
-{{- end }}
+            claimName: {{ .Release.Name }}-persistent-worker-tap
+        {{- end }}

--- a/helm-chart/templates/10-ingress-class.yaml
+++ b/helm-chart/templates/10-ingress-class.yaml
@@ -1,19 +1,17 @@
 ---
-{{- if .Values.tap.ingress.enabled }}
+{{- if .Values.ingressClass.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
-  creationTimestamp: null
+  {{- if .Values.ingressClass.labels }}
   labels:
-  {{- if .Values.tap.labels }}
-    {{- toYaml .Values.tap.labels | nindent 4 }}
+    {{- toYaml .Values.ingressClass.labels | nindent 4 }}
   {{- end }}
+  {{- if .Values.ingressClass.annotations }}
   annotations:
-  {{- if .Values.tap.annotations }}
-    {{- toYaml .Values.tap.annotations | nindent 4 }}
+    {{- toYaml .Values.ingressClass.annotations | nindent 4 }}
   {{- end }}
-  name: kubeshark-ingress-class
-  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-ingress-class
 spec:
-  controller: {{ .Values.tap.ingress.controller }}
+  controller: {{ .Values.ingressClass.controller }}
 {{- end }}

--- a/helm-chart/templates/11-ingress.yaml
+++ b/helm-chart/templates/11-ingress.yaml
@@ -1,45 +1,45 @@
 ---
-{{- if .Values.tap.ingress.enabled }}
+{{- if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    certmanager.k8s.io/cluster-issuer: {{ .Values.tap.ingress.certmanager }}
+    certmanager.k8s.io/cluster-issuer: {{ .Values.ingress.certmanager }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
-  {{- if .Values.tap.annotations }}
-    {{- toYaml .Values.tap.annotations | nindent 4 }}
+  {{- if .Values.ingress.annotations }}
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
   {{- end }}
-  creationTimestamp: null
   labels:
-  {{- if .Values.tap.labels }}
-    {{- toYaml .Values.tap.labels | nindent 4 }}
+  {{- if .Values.ingress.labels }}
+    {{- toYaml .Values.ingress.labels | nindent 4 }}
   {{- end }}
-  name: kubeshark-ingress
-  namespace: {{ .Release.Namespace }}
+  name: {{ .Release.Name }}-ingress
 spec:
-  ingressClassName: {{ .Values.tap.ingress.classname }}
+  {{- if .Values.ingressClass.enabled }}
+  ingressClassName: {{ .Release.Name }}-ingress-class  # Use the custom ingress class name
+  {{- else }}
+  ingressClassName: {{ .Values.ingress.classname }}  # Use the specified value for ingress class name
+  {{- end }}
   rules:
-    - host: {{ .Values.tap.ingress.host }}
+    - host: {{ .Values.ingress.host }}
       http:
         paths:
           - backend:
               service:
-                name: kubeshark-hub
+                name: {{ .Release.Name }}-hub
                 port:
                   number: 80
             path: /api(/|$)(.*)
             pathType: Prefix
           - backend:
               service:
-                name: kubeshark-front
+                name: {{ .Release.Name }}-front
                 port:
                   number: 80
             path: /()(.*)
             pathType: Prefix
   tls:
-  {{- if gt (len .Values.tap.ingress.tls) 0}}
-    {{- toYaml .Values.tap.ingress.tls | nindent 2 }}
+  {{- if gt (len .Values.ingress.tls) 0}}
+    {{- toYaml .Values.ingress.tls | nindent 2 }}
   {{- end }}
-status:
-  loadBalancer: {}
 {{- end }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -1,61 +1,122 @@
+# Configs for the worker-tap daemonset
 tap:
-  docker:
+  image:
     registry: docker.io/kubeshark
     tag: latest
-    imagepullpolicy: Always
-    imagepullsecrets: []
-  proxy:
-    worker:
-      srvport: 8897
-    hub:
-      port: 8898
-      srvport: 8898
-    front:
-      port: 8899
-    host: 127.0.0.1
-  regex: .*
-  namespaces: []
-  release:
-    repo: https://helm.kubeshark.co
-    name: kubeshark
-    namespace: default
-  persistentstorage: false
-  storagelimit: 200Mi
-  storageclass: standard
-  dryrun: false
-  pcap: ""
+    name: worker
+  imagepullpolicy: Always
+  port: 8897
+  persistence:
+    enabled: false
+    size: 200Mi
+    storageclass: standard
   resources:
-    worker:
-      limits:
-        cpu: 750m
-        memory: 1Gi
-      requests:
-        cpu: 50m
-        memory: 50Mi
-    hub:
-      limits:
-        cpu: 750m
-        memory: 1Gi
-      requests:
-        cpu: 50m
-        memory: 50Mi
-  servicemesh: true
-  tls: true
-  packetcapture: libpcap
-  ignoretainted: false
+    limits:
+      cpu: 750m
+      memory: 1Gi
+    requests:
+      cpu: 450m
+      memory: 150Mi
   labels: {}
   annotations: {}
+  tolerations: {}
   nodeselectorterms: []
-  ingress:
-    enabled: false
-    classname: kubeshark-ingress-class
-    controller: k8s.io/ingress-nginx
-    host: ks.svc.cluster.local
-    tls: []
-    auth:
-      approveddomains: []
-    certmanager: letsencrypt-prod
-  debug: false
+  
+  # these settings are used to configure the tap's capture settings
+  config:
+    proxy:
+      hub:
+        port: 8898
+        srvport: 8898
+      front:
+        port: 8899
+      host: 127.0.0.1
+    regex: .*
+    namespaces: []
+    servicemesh: true
+    tls: true
+    packetcapture: libpcap
+    debug: false
+  
+
+# Configs for the hub (aggregator service) and its service
+hub:
+  replicas: 1
+  labels: {}
+  annotations: {}
+  debug: false 
+  resources:
+    limits:
+      cpu: 750m
+      memory: 1Gi
+    requests:
+      cpu: 50m
+      memory: 50Mi
+  tolerations: []
+  image:
+    registry: "docker.io/kubeshark"
+    name: "hub"
+    tag: "latest"
+  imagePullPolicy: "IfNotPresent"
+  service:
+    labels: {}
+    annotations: {}
+    port: 80
+    type: ClusterIP
+
+# Configs for the web frontend and its service
+front:
+  replicas: 1
+  labels: {}
+  annotations: {}
+  image:
+    registry: "docker.io/kubeshark"
+    name: front
+    tag: "latest"
+  imagePullPolicy: "IfNotPresent"
+  resources:
+    limits:
+      cpu: 750m
+      memory: 1Gi
+    requests:
+      cpu: 50m
+      memory: 50Mi
+  tolerations: []
+  service:
+    labels: {}
+    annotations: {}
+    port: 80
+    type: ClusterIP
+
+# Ingress Configuration
+ingress:
+  enabled: false
+  className: "" # uses the generated ingressClass name by default. If a value is set, ingressClass.enabled should be false.
+  host: ks.svc.cluster.local
+  tls: []
+  # Example TLS Block for ingress
+  # - secretName: my-tls-secret
+  #   hosts:
+  #     - kubeshark.example.com
+  #     - analyzer.kubeshark.example.com
+  auth: # the domains in auth will be used to setup the 
+    approveddomains: []
+  certmanager: letsencrypt-prod
+  annotations: {}
+  labels: {}
+
+ingressClass:
+  enabled: false # if ingress.enabled is true and ingressClass.enabled is false, ingress.className must be set to an existing class.
+  controller: k8s.io/ingress-nginx
+  annotations: {}
+  labels: {}
+
+# rbac contains the values used for the serviceAccount, clusterRole and clusterRoleBinding
+rbac:
+  labels: {}
+  annotations: {}
+
+# General configs
 logs:
   file: ""
 kube:


### PR DESCRIPTION
First draft for #1394 here, mainly looking for feedback, some more things will need to change before this is fully functional.

helm template works and most of the chart settings I wanted to change are there.

## Global
- Removed creationTimestamp from everything as it will be setup automatically anyway
- Removed namespace from everything since helm will set the value to .Release.Namespace by default
- Removed the annotations and labels field from everything if not used (the "if" clause starts above it so setting `labels: {}` in most cases will result in no `labels` field to be created.
- Replaced "kubeshark" from most of the resource names to replace with the .Release.Name instead to match what is being done in other projects.

## RBAC
- Created the `rbac` structure to isolate settings to only the `serviceAccount`, `ClusterRole` and `ClusterRoleBinding`

## Hub

### Workload
- Created the `hub` structure to isolate settings for the hub.
- Converted the pod to a deployment instead.
- Replaced the individual fields for resources with an ad-lib block. This will allow setting only some (or none) of the fields.
- Replaced the tolerations with an ad-lib block. The default should be that the deployment has no toleration and experienced users with specific use-cases may add some as needed.
- Added more customization to the container image definition
- Added the containerPort definition to explicitly expose the port that was being used for the hub.


### Service
- Modified the service to be able to set another port if needed
- Targeted the `http-api` on the hub deployment

## Front

### Workload
- Created the `front` structure to isolate settings for the front.
- Converted the pod to a deployment instead.
- Replaced the hardcoded resources with an ad-lib block. This will allow setting custom resources instead of having them hardcoded.
- Replaced the tolerations with an ad-lib block. The default should be that the deployment has no toleration and experienced users with specific use-cases may add some as needed.
- Added more customization to the container image definition
- Added the containerPort definition to explicitly expose the port that was being used for the front.
- Set the `REACT_APP_HUB_PORT` to use the hub port defined in the hub service instead.

### Service
- Modified the service to be able to set another port if needed
- Targeted the `http-frontend` on the front deployment. 

## Tap workers

- Renamed the daemonset to `{{ .Release.Name}}-worker-tap` since having `daemonset` in the name is redundant.
- Replaced the individual fields for resources with an ad-lib block. This will allow setting only some (or none) of the fields.
- Replaced the tolerations with an ad-lib block. The default should be that the deployment has no toleration and experienced users with specific use-cases may add some as needed.
- Added more customization to the container image definition

## Ingress
- Moved the `ingress` and `ingressClass` out of the `tap` structure.
- Separated the ingress and ingressClass structures to allow for specific values.
- Enabling ingressClass will now force using the custom ingressClass, while `ingressClass.enabled: false` will result in using the value set in `ingress.classname`