### PR TITLE
:hammer: Add `_helpers.tpl` and `NOTES.txt` to Helm chart and refactor `labels`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ generate-helm-values: ## Generate the Helm values from config.yaml
 	./bin/kubeshark__ config > ./helm-chart/values.yaml
 
 generate-manifests: ## Generate the manifests from the Helm chart using default configuration
-	helm template ./helm-chart > ./manifests/complete.yaml
+	helm template kubeshark -n default ./helm-chart > ./manifests/complete.yaml
 
 logs-worker:
 	export LOGS_POD_PREFIX=kubeshark-worker-

--- a/helm-chart/templates/01-service-account.yaml
+++ b/helm-chart/templates/01-service-account.yaml
@@ -8,5 +8,5 @@ metadata:
   {{- if .Values.tap.annotations }}
     {{- toYaml .Values.tap.annotations | nindent 4 }}
   {{- end }}
-  name: kubeshark-service-account
+  name: {{ include "kubeshark.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/helm-chart/templates/01-service-account.yaml
+++ b/helm-chart/templates/01-service-account.yaml
@@ -2,11 +2,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  creationTimestamp: null
   labels:
-  {{- if .Values.tap.labels }}
-    {{- toYaml .Values.tap.labels | nindent 4 }}
-  {{- end }}
+    {{- include "kubeshark.labels" . | nindent 4 }}
   annotations:
   {{- if .Values.tap.annotations }}
     {{- toYaml .Values.tap.annotations | nindent 4 }}

--- a/helm-chart/templates/02-cluster-role.yaml
+++ b/helm-chart/templates/02-cluster-role.yaml
@@ -2,11 +2,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   labels:
-  {{- if .Values.tap.labels }}
-    {{- toYaml .Values.tap.labels | nindent 4 }}
-  {{- end }}
+    {{- include "kubeshark.labels" . | nindent 4 }}
   annotations:
   {{- if .Values.tap.annotations }}
     {{- toYaml .Values.tap.annotations | nindent 4 }}

--- a/helm-chart/templates/03-cluster-role-binding.yaml
+++ b/helm-chart/templates/03-cluster-role-binding.yaml
@@ -2,11 +2,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  creationTimestamp: null
   labels:
-  {{- if .Values.tap.labels }}
-    {{- toYaml .Values.tap.labels | nindent 4 }}
-  {{- end }}
+    {{- include "kubeshark.labels" . | nindent 4 }}
   annotations:
   {{- if .Values.tap.annotations }}
     {{- toYaml .Values.tap.annotations | nindent 4 }}

--- a/helm-chart/templates/03-cluster-role-binding.yaml
+++ b/helm-chart/templates/03-cluster-role-binding.yaml
@@ -16,5 +16,5 @@ roleRef:
   name: kubeshark-cluster-role
 subjects:
   - kind: ServiceAccount
-    name: kubeshark-service-account
+    name: {{ include "kubeshark.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}

--- a/helm-chart/templates/04-hub-pod.yaml
+++ b/helm-chart/templates/04-hub-pod.yaml
@@ -45,7 +45,7 @@ spec:
           cpu: {{ .Values.tap.resources.hub.requests.cpu }}
           memory: {{ .Values.tap.resources.hub.requests.memory }}
   dnsPolicy: ClusterFirstWithHostNet
-  serviceAccountName: kubeshark-service-account
+  serviceAccountName: {{ include "kubeshark.serviceAccountName" . }}
   terminationGracePeriodSeconds: 0
   tolerations:
     - effect: NoExecute

--- a/helm-chart/templates/04-hub-pod.yaml
+++ b/helm-chart/templates/04-hub-pod.yaml
@@ -2,13 +2,10 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  creationTimestamp: null
   labels:
     app: kubeshark-hub
     sidecar.istio.io/inject: "false"
-  {{- if .Values.tap.labels }}
-    {{- toYaml .Values.tap.labels | nindent 4 }}
-  {{- end }}
+    {{- include "kubeshark.labels" . | nindent 4 }}
   annotations:
   {{- if .Values.tap.annotations }}
     {{- toYaml .Values.tap.annotations | nindent 4 }}

--- a/helm-chart/templates/05-hub-service.yaml
+++ b/helm-chart/templates/05-hub-service.yaml
@@ -2,11 +2,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
-  {{- if .Values.tap.labels }}
-    {{- toYaml .Values.tap.labels | nindent 4 }}
-  {{- end }}
+    {{- include "kubeshark.labels" . | nindent 4 }}
   annotations:
   {{- if .Values.tap.annotations }}
     {{- toYaml .Values.tap.annotations | nindent 4 }}

--- a/helm-chart/templates/06-front-pod.yaml
+++ b/helm-chart/templates/06-front-pod.yaml
@@ -2,13 +2,10 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  creationTimestamp: null
   labels:
     app: kubeshark-front
     sidecar.istio.io/inject: "false"
-  {{- if .Values.tap.labels }}
-    {{- toYaml .Values.tap.labels | nindent 4 }}
-  {{- end }}
+    {{- include "kubeshark.labels" . | nindent 4 }}
   annotations:
   {{- if .Values.tap.annotations }}
     {{- toYaml .Values.tap.annotations | nindent 4 }}

--- a/helm-chart/templates/06-front-pod.yaml
+++ b/helm-chart/templates/06-front-pod.yaml
@@ -48,7 +48,7 @@ spec:
       configMap:
         name:  kubeshark-nginx-config
   dnsPolicy: ClusterFirstWithHostNet
-  serviceAccountName: kubeshark-service-account
+  serviceAccountName: {{ include "kubeshark.serviceAccountName" . }}
   terminationGracePeriodSeconds: 0
   tolerations:
     - effect: NoExecute

--- a/helm-chart/templates/07-front-service.yaml
+++ b/helm-chart/templates/07-front-service.yaml
@@ -2,11 +2,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
-  {{- if .Values.tap.labels }}
-    {{- toYaml .Values.tap.labels | nindent 4 }}
-  {{- end }}
+    {{- include "kubeshark.labels" . | nindent 4 }}
   annotations:
   {{- if .Values.tap.annotations }}
     {{- toYaml .Values.tap.annotations | nindent 4 }}

--- a/helm-chart/templates/08-persistent-volume-claim.yaml
+++ b/helm-chart/templates/08-persistent-volume-claim.yaml
@@ -3,11 +3,8 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  creationTimestamp: null
   labels:
-  {{- if .Values.tap.labels }}
-    {{- toYaml .Values.tap.labels | nindent 4 }}
-  {{- end }}
+    {{- include "kubeshark.labels" . | nindent 4 }}
   annotations:
   {{- if .Values.tap.annotations }}
     {{- toYaml .Values.tap.annotations | nindent 4 }}

--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -2,13 +2,10 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  creationTimestamp: null
   labels:
     app: kubeshark-worker-daemon-set
     sidecar.istio.io/inject: "false"
-  {{- if .Values.tap.labels }}
-    {{- toYaml .Values.tap.labels | nindent 4 }}
-  {{- end }}
+    {{- include "kubeshark.labels" . | nindent 4 }}
   annotations:
   {{- if .Values.tap.annotations }}
     {{- toYaml .Values.tap.annotations | nindent 4 }}
@@ -24,7 +21,6 @@ spec:
     {{- end }}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: kubeshark-worker-daemon-set
       {{- if .Values.tap.labels }}

--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -84,7 +84,7 @@ spec:
 {{- end }}
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
-      serviceAccountName: kubeshark-service-account
+      serviceAccountName: {{ include "kubeshark.serviceAccountName" . }}
       terminationGracePeriodSeconds: 0
       tolerations:
         - effect: NoExecute

--- a/helm-chart/templates/10-ingress-class.yaml
+++ b/helm-chart/templates/10-ingress-class.yaml
@@ -3,11 +3,8 @@
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
-  creationTimestamp: null
   labels:
-  {{- if .Values.tap.labels }}
-    {{- toYaml .Values.tap.labels | nindent 4 }}
-  {{- end }}
+    {{- include "kubeshark.labels" . | nindent 4 }}
   annotations:
   {{- if .Values.tap.annotations }}
     {{- toYaml .Values.tap.annotations | nindent 4 }}

--- a/helm-chart/templates/11-ingress.yaml
+++ b/helm-chart/templates/11-ingress.yaml
@@ -6,9 +6,7 @@ metadata:
   annotations:
     certmanager.k8s.io/cluster-issuer: {{ .Values.tap.ingress.certmanager }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
-  {{- if .Values.tap.annotations }}
-    {{- toYaml .Values.tap.annotations | nindent 4 }}
-  {{- end }}
+    {{- include "kubeshark.labels" . | nindent 4 }}
   creationTimestamp: null
   labels:
   {{- if .Values.tap.labels }}

--- a/helm-chart/templates/11-ingress.yaml
+++ b/helm-chart/templates/11-ingress.yaml
@@ -6,12 +6,11 @@ metadata:
   annotations:
     certmanager.k8s.io/cluster-issuer: {{ .Values.tap.ingress.certmanager }}
     nginx.ingress.kubernetes.io/rewrite-target: /$2
-    {{- include "kubeshark.labels" . | nindent 4 }}
-  creationTimestamp: null
-  labels:
-  {{- if .Values.tap.labels }}
-    {{- toYaml .Values.tap.labels | nindent 4 }}
+  {{- if .Values.tap.annotations }}
+    {{- toYaml .Values.tap.annotations | nindent 4 }}
   {{- end }}
+  labels:
+    {{- include "kubeshark.labels" . | nindent 4 }}
   name: kubeshark-ingress
   namespace: {{ .Release.Namespace }}
 spec:

--- a/helm-chart/templates/12-nginx-config.yaml
+++ b/helm-chart/templates/12-nginx-config.yaml
@@ -4,6 +4,8 @@ kind: ConfigMap
 metadata:
   name: kubeshark-nginx-config
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubeshark.labels" . | nindent 4 }}
 data:
   default.conf: |
     server {

--- a/helm-chart/templates/NOTES.txt
+++ b/helm-chart/templates/NOTES.txt
@@ -1,0 +1,27 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your deployment has been successful. The release is named {{ .Release.Name }} and it has been deployed in the {{ .Release.Namespace }} namespace.
+
+{{- if .Values.tap.ingress.enabled }}
+
+{{ if not .Values.license -}}
+warning:
+> Ingress option enabled but license not set. The application should not work as expected.
+> Get a lisence at https://console.kubeshark.co/
+{{- else }}
+You can now access the application through the following URL: 
+http{{ if .Values.tap.ingress.tls }}s{{ end }}://{{ .Values.tap.ingress.host }}
+{{- end -}}
+
+{{- else }}
+To access the application, follow these steps:
+
+1. Perform port forwarding with the following commands:
+
+    kubectl port-forward -n {{ .Release.Namespace }} service/kubeshark-hub 8898:80 & \
+    kubectl port-forward -n {{ .Release.Namespace }} service/kubeshark-front 8899:80
+
+2. Once port forwarding is done, you can access the application by visiting the following URL in your web browser:
+    http://0.0.0.0:8899
+
+{{ end }}

--- a/helm-chart/templates/NOTES.txt
+++ b/helm-chart/templates/NOTES.txt
@@ -9,7 +9,7 @@ warning:
 > Ingress option enabled but license not set. The application should not work as expected.
 > Get a lisence at https://console.kubeshark.co/
 {{- else }}
-You can now access the application through the following URL: 
+You can now access the application through the following URL:
 http{{ if .Values.tap.ingress.tls }}s{{ end }}://{{ .Values.tap.ingress.host }}
 {{- end -}}
 

--- a/helm-chart/templates/NOTES.txt
+++ b/helm-chart/templates/NOTES.txt
@@ -7,7 +7,7 @@ Your deployment has been successful. The release is named {{ .Release.Name }} an
 {{ if not .Values.license -}}
 warning:
 > Ingress option enabled but license not set. The application should not work as expected.
-> Get a lisence at https://console.kubeshark.co/
+> Get a license at https://console.kubeshark.co/
 {{- else }}
 You can now access the application through the following URL:
 http{{ if .Values.tap.ingress.tls }}s{{ end }}://{{ .Values.tap.ingress.host }}

--- a/helm-chart/templates/NOTES.txt
+++ b/helm-chart/templates/NOTES.txt
@@ -1,4 +1,4 @@
-Thank you for installing {{ .Chart.Name }}.
+Thank you for installing {{ title .Chart.Name }}.
 
 Your deployment has been successful. The release is named {{ .Release.Name }} and it has been deployed in the {{ .Release.Namespace }} namespace.
 

--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -1,0 +1,68 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kubeshark.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kubeshark.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kubeshark.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kubeshark.labels" -}}
+helm.sh/chart: {{ include "kubeshark.chart" . }}
+{{ include "kubeshark.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.additionalLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- if .Values.tap.labels }}
+{{- toYaml .Values.tap.labels}}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kubeshark.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kubeshark.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "kubeshark.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "kubeshark.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -44,7 +44,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{ toYaml . }}
 {{- end }}
 {{- if .Values.tap.labels }}
-{{- toYaml .Values.tap.labels}}
+{{ toYaml .Values.tap.labels }}
 {{- end }}
 {{- end }}
 

--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -60,9 +60,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "kubeshark.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
+{{- if and .Values.serviceAccount .Values.serviceAccount.create }}
 {{- default (include "kubeshark.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- printf "%s-service-account" .Release.Name }}
 {{- end }}
 {{- end }}

--- a/manifests/complete.yaml
+++ b/manifests/complete.yaml
@@ -3,8 +3,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  creationTimestamp: null
   labels:
+    helm.sh/chart: kubeshark-41.7
+    app.kubernetes.io/name: kubeshark
+    app.kubernetes.io/instance: kubeshark
+    app.kubernetes.io/version: "41.7"
+    app.kubernetes.io/managed-by: Helm
   annotations:
   name: kubeshark-service-account
   namespace: default
@@ -15,6 +19,12 @@ kind: ConfigMap
 metadata:
   name: kubeshark-nginx-config
   namespace: default
+  labels:
+    helm.sh/chart: kubeshark-41.7
+    app.kubernetes.io/name: kubeshark
+    app.kubernetes.io/instance: kubeshark
+    app.kubernetes.io/version: "41.7"
+    app.kubernetes.io/managed-by: Helm
 data:
   default.conf: |
     server {
@@ -37,8 +47,12 @@ data:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   labels:
+    helm.sh/chart: kubeshark-41.7
+    app.kubernetes.io/name: kubeshark
+    app.kubernetes.io/instance: kubeshark
+    app.kubernetes.io/version: "41.7"
+    app.kubernetes.io/managed-by: Helm
   annotations:
   name: kubeshark-cluster-role
   namespace: default
@@ -63,8 +77,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  creationTimestamp: null
   labels:
+    helm.sh/chart: kubeshark-41.7
+    app.kubernetes.io/name: kubeshark
+    app.kubernetes.io/instance: kubeshark
+    app.kubernetes.io/version: "41.7"
+    app.kubernetes.io/managed-by: Helm
   annotations:
   name: kubeshark-cluster-role-binding
   namespace: default
@@ -81,8 +99,12 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
+    helm.sh/chart: kubeshark-41.7
+    app.kubernetes.io/name: kubeshark
+    app.kubernetes.io/instance: kubeshark
+    app.kubernetes.io/version: "41.7"
+    app.kubernetes.io/managed-by: Helm
   annotations:
   name: kubeshark-hub
   namespace: default
@@ -101,8 +123,12 @@ status:
 apiVersion: v1
 kind: Service
 metadata:
-  creationTimestamp: null
   labels:
+    helm.sh/chart: kubeshark-41.7
+    app.kubernetes.io/name: kubeshark
+    app.kubernetes.io/instance: kubeshark
+    app.kubernetes.io/version: "41.7"
+    app.kubernetes.io/managed-by: Helm
   annotations:
   name: kubeshark-front
   namespace: default
@@ -121,10 +147,14 @@ status:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  creationTimestamp: null
   labels:
     app: kubeshark-worker-daemon-set
     sidecar.istio.io/inject: "false"
+    helm.sh/chart: kubeshark-41.7
+    app.kubernetes.io/name: kubeshark
+    app.kubernetes.io/instance: kubeshark
+    app.kubernetes.io/version: "41.7"
+    app.kubernetes.io/managed-by: Helm
   annotations:
   name: kubeshark-worker-daemon-set
   namespace: default
@@ -134,7 +164,6 @@ spec:
       app: kubeshark-worker-daemon-set
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: kubeshark-worker-daemon-set
       name: kubeshark-worker-daemon-set
@@ -201,10 +230,14 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  creationTimestamp: null
   labels:
     app: kubeshark-hub
     sidecar.istio.io/inject: "false"
+    helm.sh/chart: kubeshark-41.7
+    app.kubernetes.io/name: kubeshark
+    app.kubernetes.io/instance: kubeshark
+    app.kubernetes.io/version: "41.7"
+    app.kubernetes.io/managed-by: Helm
   annotations:
   name: kubeshark-hub
   namespace: default
@@ -254,10 +287,14 @@ status: {}
 apiVersion: v1
 kind: Pod
 metadata:
-  creationTimestamp: null
   labels:
     app: kubeshark-front
     sidecar.istio.io/inject: "false"
+    helm.sh/chart: kubeshark-41.7
+    app.kubernetes.io/name: kubeshark
+    app.kubernetes.io/instance: kubeshark
+    app.kubernetes.io/version: "41.7"
+    app.kubernetes.io/managed-by: Helm
   annotations:
   name: kubeshark-front
   namespace: default


### PR DESCRIPTION
This PR includes:

- standard labels using a `_helpers.tpl`  file to create those labels.
- removed all the `creationTimestamp` inputs.
- Included a `NOTES.txt` file to help users after the installing.
- Service Account Name also generated by `_helpers.tpl`  file.