### PR TITLE
🔧  Add an option to disable telemetry into config

### DIFF
--- a/cmd/tapRunner.go
+++ b/cmd/tapRunner.go
@@ -107,7 +107,7 @@ func tap() {
 	go watchHubPod(ctx, kubernetesProvider, cancel)
 	go watchFrontPod(ctx, kubernetesProvider, cancel)
 	if !config.Config.Tap.NoTelemetry {
-		// todo: add telemtry routine here
+		log.Info().Msg("Starting Telemetry...")
 	}
 
 	// block until exit signal or error

--- a/cmd/tapRunner.go
+++ b/cmd/tapRunner.go
@@ -106,6 +106,9 @@ func tap() {
 	go watchHubEvents(ctx, kubernetesProvider, cancel)
 	go watchHubPod(ctx, kubernetesProvider, cancel)
 	go watchFrontPod(ctx, kubernetesProvider, cancel)
+	if !config.Config.Tap.NoTelemetry {
+		// todo: add telemtry routine here
+	}
 
 	// block until exit signal or error
 	utils.WaitForTermination(ctx, cancel)

--- a/cmd/tapRunner.go
+++ b/cmd/tapRunner.go
@@ -75,6 +75,8 @@ func tap() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel() // cancel will be called when this function exits
 
+	log.Info().Bool("enabled", !config.Config.Tap.NoTelemetry).Msg("Telemetry")
+
 	state.targetNamespaces = kubernetesProvider.GetNamespaces()
 
 	log.Info().Strs("namespaces", state.targetNamespaces).Msg("Targeting pods in:")
@@ -106,9 +108,6 @@ func tap() {
 	go watchHubEvents(ctx, kubernetesProvider, cancel)
 	go watchHubPod(ctx, kubernetesProvider, cancel)
 	go watchFrontPod(ctx, kubernetesProvider, cancel)
-	if !config.Config.Tap.NoTelemetry {
-		log.Info().Msg("Starting Telemetry...")
-	}
 
 	// block until exit signal or error
 	utils.WaitForTermination(ctx, cancel)

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,7 @@ const (
 	FieldNameTag   = "yaml"
 	ReadonlyTag    = "readonly"
 	DebugFlag      = "debug"
+	TelemetryFlag  = "no-telemetry"
 )
 
 var (

--- a/config/config.go
+++ b/config/config.go
@@ -28,7 +28,6 @@ const (
 	FieldNameTag   = "yaml"
 	ReadonlyTag    = "readonly"
 	DebugFlag      = "debug"
-	TelemetryFlag  = "no-telemetry"
 )
 
 var (

--- a/config/configStructs/tapConfig.go
+++ b/config/configStructs/tapConfig.go
@@ -123,7 +123,7 @@ type TapConfig struct {
 	Ingress           IngressConfig         `yaml:"ingress" json:"ingress"`
 	IPv6              bool                  `yaml:"ipv6" json:"ipv6" default:"true"`
 	Debug             bool                  `yaml:"debug" json:"debug" default:"false"`
-	NoTelemetry       bool                  `yaml:"noTelemetry" json:"noTelemetry" default:"false"`
+	NoTelemetry       bool                  `yaml:"notelemetry" json:"notelemetry" default:"false"`
 }
 
 func (config *TapConfig) PodRegex() *regexp.Regexp {

--- a/config/configStructs/tapConfig.go
+++ b/config/configStructs/tapConfig.go
@@ -123,6 +123,7 @@ type TapConfig struct {
 	Ingress           IngressConfig         `yaml:"ingress" json:"ingress"`
 	IPv6              bool                  `yaml:"ipv6" json:"ipv6" default:"true"`
 	Debug             bool                  `yaml:"debug" json:"debug" default:"false"`
+	NoTelemetry       bool                  `yaml:"noTelemetry" json:"noTelemetry" default:"false"`
 }
 
 func (config *TapConfig) PodRegex() *regexp.Regexp {

--- a/helm-chart/templates/04-hub-deployment.yaml
+++ b/helm-chart/templates/04-hub-deployment.yaml
@@ -28,7 +28,7 @@ spec:
           command:
             - ./hub
             {{ .Values.tap.debug | ternary "- -debug" "" }}
-            {{ .Values.tap.noTelemetry | ternary "- -no-telemetry" "" }}
+            {{ .Values.tap.notelemetry | ternary "- -no-telemetry" "" }}
           envFrom:
             - configMapRef:
                 name: kubeshark-config-map

--- a/helm-chart/templates/04-hub-deployment.yaml
+++ b/helm-chart/templates/04-hub-deployment.yaml
@@ -28,7 +28,8 @@ spec:
           command:
             - ./hub
             {{ .Values.tap.debug | ternary "- -debug" "" }}
-            {{ .Values.tap.notelemetry | ternary "- -no-telemetry" "" }}
+            - e
+            - TELEMETRY_DISABLED={{ .Values.tap.notelemetry }}
           envFrom:
             - configMapRef:
                 name: kubeshark-config-map

--- a/helm-chart/templates/04-hub-deployment.yaml
+++ b/helm-chart/templates/04-hub-deployment.yaml
@@ -28,6 +28,7 @@ spec:
           command:
             - ./hub
             {{ .Values.tap.debug | ternary "- -debug" "" }}
+            {{ .Values.tap.noTelemetry | ternary "- -no-telemetry" "" }}
           envFrom:
             - configMapRef:
                 name: kubeshark-config-map

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -43,6 +43,7 @@ tap:
           operator: In
           values:
             - linux
+  notelemetry: false
   packetcapture: libpcap
   pcap: ""
   persistentstorage: false


### PR DESCRIPTION
now Telemetry can be set on/off based on config flag

if `tap.noTelemetry: true` no Telemetry will run, if `false` (default), telemetry will be sent.