### PR TITLE
Add PF_RING related changes to docs and helm

### DIFF
--- a/config/configStructs/tapConfig.go
+++ b/config/configStructs/tapConfig.go
@@ -129,8 +129,9 @@ type TapConfig struct {
 	Ingress                 IngressConfig         `yaml:"ingress" json:"ingress"`
 	IPv6                    bool                  `yaml:"ipv6" json:"ipv6" default:"true"`
 	Debug                   bool                  `yaml:"debug" json:"debug" default:"false"`
-	NoKernelModule          bool                  `yaml:"noKernelModule" json:"noKernelModule" default:"false"`
-	Telemetry               TelemetryConfig       `yaml:"telemetry" json:"telemetry"`
+	// TODO: remove completely?
+	NoKernelModule bool            `yaml:"noKernelModule" json:"noKernelModule" default:"false"`
+	Telemetry      TelemetryConfig `yaml:"telemetry" json:"telemetry"`
 }
 
 func (config *TapConfig) PodRegex() *regexp.Regexp {

--- a/helm-chart/PF_RING.md
+++ b/helm-chart/PF_RING.md
@@ -1,0 +1,7 @@
+# PF_RING
+
+## Overview
+
+PF_RING™ is an advanced Linux kernel module and user-space framework designed for high-speed packet processing. It offers a uniform API for packet processing applications, enabling efficient handling of large volumes of network data.
+
+For comprehensive information on PF_RING™, please visit the [User's Guide]((https://www.ntop.org/guides/pf_ring) and access detailed [API Documentation](http://www.ntop.org/guides/pf_ring_api/files.html).

--- a/helm-chart/PF_RING.md
+++ b/helm-chart/PF_RING.md
@@ -1,5 +1,21 @@
 # PF_RING
 
+<!-- TOC -->
+
+- [PF_RING](#pf_ring)
+    - [Overview](#overview)
+    - [Provisioning mode](#provisioning-mode)
+    - [Selection of Provisioning Mode](#selection-of-provisioning-mode)
+        - [Pre-built kernel module exists and external egress allowed](#pre-built-kernel-module-exists-and-external-egress-allowed)
+        - [Pre-built kernel module doesn't exist or external egress isn't allowed](#pre-built-kernel-module-doesnt-exist-or-external-egress-isnt-allowed)
+            - [Steps to Use kmm with Custom Containers](#steps-to-use-kmm-with-custom-containers)
+    - [Appendix A: pre-build kernel versions](#appendix-a-pre-build-kernel-versions)
+    - [Appendix B: PF_RING kernel module compilation](#appendix-b-pf_ring-kernel-module-compilation)
+        - [Automated complilation](#automated-complilation)
+        - [Manual compilation](#manual-compilation)
+
+<!-- /TOC -->
+
 ## Overview
 
 PF_RING™ is an advanced Linux kernel module and user-space framework designed for high-speed packet processing. It offers a uniform API for packet processing applications, enabling efficient handling of large volumes of network data.

--- a/helm-chart/PF_RING.md
+++ b/helm-chart/PF_RING.md
@@ -16,7 +16,7 @@ In this mode, the Kubeshark worker retrieves the necessary PF_RING kernel module
 
 2. `kmm`
 
-The Kernel Module Management controller ([KMM]((https://kmm.sigs.k8s.io/documentation/deploy_kmod/))) acquires the required PF_RING kernel module version from a Docker container and loads it onto the node
+The Kernel Module Management controller ([KMM](https://kmm.sigs.k8s.io/documentation/deploy_kmod/)) acquires the required PF_RING kernel module version from a Docker container and loads it onto the node
 
 ## Selection of Provisioning Mode
 

--- a/helm-chart/PF_RING.md
+++ b/helm-chart/PF_RING.md
@@ -35,11 +35,11 @@ In this mode, the Kubeshark worker retrieves the necessary PF_RING kernel module
 
 The Kernel Module Management controller ([KMM](https://kmm.sigs.k8s.io/documentation/deploy_kmod/)) acquires the required PF_RING kernel module version from a Docker container and loads it onto the node
 
-> mode=kmm is suitable for air-gapped environments. 
+> mode=kmm is suitable for air-gapped environments.
 
 ## Selection of Provisioning Mode
 
-> This step is optional. In case mode=auto and no PF_RING kernel module is found Kubeshark falls back to `libpcap` if `PF_RING` kernel module not available 
+> This step is optional. In case mode=auto and no PF_RING kernel module is found Kubeshark falls back to `libpcap` if `PF_RING` kernel module not available
 
 Prior to choosing a method, it is essential to verify if a PF_RING kernel module is already built for your kernel version.
 Kubeshark provides additional CLI tool for this purpose - [pf-ring-compiler](https://github.com/kubeshark/pf-ring-compiler).
@@ -69,7 +69,7 @@ If PF_RING kernel modules are already available for the target nodes (cluster is
 |auto|kmm|
 |----|---|
 | `SYS_MODULE` capability required for Kubeshark | `SYS_MODULE` capability is **not** required for Kubeshark|
-| no additional dependencies | (!)requires `cert-manager` and `KMM` installed (follow [instructions](https://kmm.sigs.k8s.io/documentation/install/)) |
+| no additional dependencies | (!)requires `cert-manager` and `KMM` installed (follow [instructions](https://kmm.sigs.k8s.io/documentation/install/) or a specific [cloud platform guide](https://kmm.sigs.k8s.io/lab/)) |
 | Kubeshark falls back to `libpcap` if `PF_RING` kernel module not available | Kubshark waits until PF_RING is loaded with KMM|
 | module is downloaded from S3 bucket in AWS | module is loaded from `kubeshark/pf-ring-module:<kernel version>` container|
 | requires egress connectivity to AWS S3 endpoints | can work in an air-gapped environment when the docker images are stored in a local container registry|
@@ -95,7 +95,7 @@ Create `Dockerfile` in the folder with PF_RING kernel module:
 FROM alpine:3.18
 ARG KERNEL_VERSION
 
-COPY pf-ring-${KERNEL_VERSION}.ko /opt/lib/modules/${KERNEL_VERSION}/pf_ring.ko 
+COPY pf-ring-${KERNEL_VERSION}.ko /opt/lib/modules/${KERNEL_VERSION}/pf_ring.ko
 RUN apk add kmod
 
 RUN depmod -b /opt ${KERNEL_VERSION}

--- a/helm-chart/PF_RING.md
+++ b/helm-chart/PF_RING.md
@@ -9,8 +9,7 @@
         - [Pre-built kernel module exists and external egress allowed](#pre-built-kernel-module-exists-and-external-egress-allowed)
         - [Pre-built kernel module doesn't exist or external egress isn't allowed](#pre-built-kernel-module-doesnt-exist-or-external-egress-isnt-allowed)
             - [Steps to Use kmm with Custom Containers](#steps-to-use-kmm-with-custom-containers)
-    - [Appendix A: pre-build kernel versions](#appendix-a-pre-build-kernel-versions)
-    - [Appendix B: PF_RING kernel module compilation](#appendix-b-pf_ring-kernel-module-compilation)
+    - [Appendix A: PF_RING kernel module compilation](#appendix-a-pf_ring-kernel-module-compilation)
         - [Automated complilation](#automated-complilation)
         - [Manual compilation](#manual-compilation)
 
@@ -36,35 +35,37 @@ The Kernel Module Management controller ([KMM](https://kmm.sigs.k8s.io/documenta
 
 ## Selection of Provisioning Mode
 
-Prior to choosing a method, it is essential to verify if a PF_RING kernel module is already built for your kernel version. This can be done by running:
+Prior to choosing a method, it is essential to verify if a PF_RING kernel module is already built for your kernel version.
+Kubeshark provides additional CLI tool for this purpose - [pf-ring-compiler](https://github.com/kubeshark/pf-ring-compiler).
+
+Compatibility verification can be done by running:
 
 ```
-# TODO: develop this command
-# 1. collect list of nodes and theirs kernel verisons
-# 2. download json with available kernel versions
-# 3. compare and provide report
-kubeshark pfring compatibility
-
-# example output
-| node                                          | kernel version                | exists |
-|-----------------------------------------------|-------------------------------|--------|
-| ip-192-168-34-216.us-west-2.compute.internal  | 5.10.198-187.748.amzn2.x86_64 | true   |
-
-Modules for all kernel versions exist: true
+pf-ring-compiler compatibility
 ```
 
 This command checks for the availability of kernel modules for the kernel versions running across all nodes in the Kubernetes cluster.
 
+Example output for a compatible cluster:
+```
+Node                                          Kernel Version                 Supported
+ip-192-168-77-230.us-west-2.compute.internal  5.10.199-190.747.amzn2.x86_64  true
+ip-192-168-34-216.us-west-2.compute.internal  5.10.199-190.747.amzn2.x86_64  true
+
+Cluster is compatible
+```
+
+
 ### Pre-built kernel module exists and external egress allowed
 
-If PF_RING kernel modules are already available for the target nodes, both `auto` and `kmm` modes are applicable.
+If PF_RING kernel modules are already available for the target nodes (cluster is compatible), both `auto` and `kmm` modes are applicable.
 
 |auto|kmm|
 |----|---|
-| `SYS_MODULE` capability required for Kubeshark | `SYS_MODULE` capability required for Kubeshark|
-| no additional dependencies | (!)requires `cert-manager` and `KMM` installed (follow [instructions](https://kmm.sigs.k8s.io/#installation-guide)) |
+| `SYS_MODULE` capability required for Kubeshark | `SYS_MODULE` capability is not required for Kubeshark|
+| no additional dependencies | (!)requires `cert-manager` and `KMM` installed (follow [instructions](https://kmm.sigs.k8s.io/documentation/install/)) |
 | Kubeshark falls back to `libpcap` if `PF_RING` kernel module not available | Kubshark waits until PF_RING is loaded with KMM|
-| module is downloaded from S3 bucket in AWS | module is loaded from `ubehq/pf-ring-module:<kernel version>` container|
+| module is downloaded from S3 bucket in AWS | module is loaded from `kubeshark/pf-ring-module:<kernel version>` container|
 | requires egress connectivity to AWS S3 endpoints | requires egress connectivity to Docker Hub container registry|
 
 
@@ -117,18 +118,7 @@ tap:
 ```
 
 
-## Appendix A: pre-build kernel versions
-
-
-| Kernel version | Container |
-|----------------|-----------|
-|5.10.198-187.748.amzn2.x86_64|kubehq/pf-ring-module:5.10.198-187.748.amzn2.x86_64|
-|5.10.199-190.747.amzn2.x86_64|kubehq/pf-ring-module:5.10.199-190.747.amzn2.x86_64|
-|5.14.0-362.8.1.el9_3.x86_64|kubehq/pf-ring-module:5.14.0-362.8.1.el9_3.x86_64|
-|5.15.0-1050-aws|kubehq/pf-ring-module:5.15.0-1050-aws|
-
-
-## Appendix B: PF_RING kernel module compilation
+## Appendix A: PF_RING kernel module compilation
 
 PF_RING kernel module compilation can be completed automatically or manually.
 

--- a/helm-chart/PF_RING.md
+++ b/helm-chart/PF_RING.md
@@ -5,3 +5,67 @@
 PF_RING™ is an advanced Linux kernel module and user-space framework designed for high-speed packet processing. It offers a uniform API for packet processing applications, enabling efficient handling of large volumes of network data.
 
 For comprehensive information on PF_RING™, please visit the [User's Guide]((https://www.ntop.org/guides/pf_ring) and access detailed [API Documentation](http://www.ntop.org/guides/pf_ring_api/files.html).
+
+## Provisioning mode
+
+There are two ways to approach PF_RING kernel module load on the nodes:
+
+1. `auto`
+
+Kubeshark worker takes required PF_RING kernel module version from S3 and loads it on the node.
+
+2. `kmm`
+
+Kernel Module Management controller([KMM](https://kmm.sigs.k8s.io/documentation/deploy_kmod/)) takes required PF_RING kernel module version
+from Docker container and loads it on the node.
+
+## What mode to use?
+
+Before deciding what methot to use, it is important to find out if there is PF_RING kernel module built already for your kernel version.
+It can be done via runnig:
+
+```
+kubeshark pfring compatibility
+```
+
+This command verifies if there are kernel modules availabale for the kernel versions running on all nodes in Kubernets cluster.
+
+### Pre-built kernel module exists and external egress allowed
+
+If PF_RING kernel modules exist already for the target nodes, both `auto` and `kmm` provisioning modes can be used.
+
+|auto|kmm|
+|----|---|
+| `SYS_MODULE` capability required for Kubeshark | `SYS_MODULE` capability required for Kubeshark|
+| no additional dependencies | (!)requires `cert-manager` and `KMM` installed (follow [instructions](https://kmm.sigs.k8s.io/#installation-guide)) |
+| Kubeshark falls back to `libpcap` if `PF_RING` kernel module not available | Kubshark waits until PF_RING is loaded with KMM|
+| module is downloaded from S3 bucket in AWS | module is loaded from `ubehq/pf-ring-module:<kernel version>` container|
+| requires egress connectivity to AWS S3 endpoints | requires egress connectivity to Docker Hub container registry|
+
+
+### Pre-built kernel module doesn't exist or external egress isn't allowed
+
+If PF_RING kernel modules don't exist yet for the target nodes, only `kmm` provisioning mode can be used (`auto` mode will still start Kubeshark, but with `libpcap`, not `PF_RING`).
+This mode allows configuration of the custom container images as the source for PF_RING kernel modules.
+That also means private container registries can be used to load PF_RING kernel module.
+
+Follow these steps to use `kmm` with custom containers:
+
+1.
+
+Helm configuration option `tap.kernelModule.mode` controls the wa
+
+
+## Appendix A: pre-build kernel versions
+
+
+| Kernel version | Container |
+|----------------|-----------|
+|5.10.198-187.748.amzn2.x86_64|kubehq/pf-ring-module:5.10.198-187.748.amzn2.x86_64|
+|5.10.199-190.747.amzn2.x86_64|kubehq/pf-ring-module:5.10.199-190.747.amzn2.x86_64|
+|5.14.0-362.8.1.el9_3.x86_64|kubehq/pf-ring-module:5.14.0-362.8.1.el9_3.x86_64|
+|5.15.0-1050-aws|kubehq/pf-ring-module:5.15.0-1050-aws|
+
+## Appendix B: PF_RING kernel module custom container build
+
+Build

--- a/helm-chart/PF_RING.md
+++ b/helm-chart/PF_RING.md
@@ -41,7 +41,7 @@ Kubeshark provides additional CLI tool for this purpose - [pf-ring-compiler](htt
 Compatibility verification can be done by running:
 
 ```
-pf-ring-compiler compatibility
+pfring-compiler compatibility
 ```
 
 This command checks for the availability of kernel modules for the kernel versions running across all nodes in the Kubernetes cluster.
@@ -127,8 +127,7 @@ PF_RING kernel module compilation can be completed automatically or manually.
 In case your Kubernetes workers run supported Linux distribution, `kubeshark` CLI can be used to build PF_RING module:
 
 ```
-# currently implemented in pf-ring-compiler
-kubeshark pfring compile --target <distro>
+pfring-compiler compile --target <distro>
 ```
 
 This command requires:

--- a/helm-chart/PF_RING.md
+++ b/helm-chart/PF_RING.md
@@ -29,11 +29,17 @@ There are two approaches for loading the PF_RING kernel module on nodes:
 
 In this mode, the Kubeshark worker retrieves the necessary PF_RING kernel module version from an S3 bucket and loads it onto the node.
 
+> mode=auto requires an active internet connection and is not suitable for air-gapped environments.
+
 2. `kmm`
 
 The Kernel Module Management controller ([KMM](https://kmm.sigs.k8s.io/documentation/deploy_kmod/)) acquires the required PF_RING kernel module version from a Docker container and loads it onto the node
 
+> mode=kmm is suitable for air-gapped environments. 
+
 ## Selection of Provisioning Mode
+
+> This step is optional. In case mode=auto and no PF_RING kernel module is found Kubeshark falls back to `libpcap` if `PF_RING` kernel module not available 
 
 Prior to choosing a method, it is essential to verify if a PF_RING kernel module is already built for your kernel version.
 Kubeshark provides additional CLI tool for this purpose - [pf-ring-compiler](https://github.com/kubeshark/pf-ring-compiler).
@@ -62,11 +68,11 @@ If PF_RING kernel modules are already available for the target nodes (cluster is
 
 |auto|kmm|
 |----|---|
-| `SYS_MODULE` capability required for Kubeshark | `SYS_MODULE` capability is not required for Kubeshark|
+| `SYS_MODULE` capability required for Kubeshark | `SYS_MODULE` capability is **not** required for Kubeshark|
 | no additional dependencies | (!)requires `cert-manager` and `KMM` installed (follow [instructions](https://kmm.sigs.k8s.io/documentation/install/)) |
 | Kubeshark falls back to `libpcap` if `PF_RING` kernel module not available | Kubshark waits until PF_RING is loaded with KMM|
 | module is downloaded from S3 bucket in AWS | module is loaded from `kubeshark/pf-ring-module:<kernel version>` container|
-| requires egress connectivity to AWS S3 endpoints | requires egress connectivity to Docker Hub container registry|
+| requires egress connectivity to AWS S3 endpoints | can work in an air-gapped environment when the docker images are stored in a local container registry|
 
 
 ### Pre-built kernel module doesn't exist or external egress isn't allowed
@@ -89,7 +95,7 @@ Create `Dockerfile` in the folder with PF_RING kernel module:
 FROM alpine:3.18
 ARG KERNEL_VERSION
 
-COPY pf-ring-${KERNEL_VERSION}.ko /opt/lib/modules/${KERNEL_VERSION}/pf_ring.ko
+COPY pf-ring-${KERNEL_VERSION}.ko /opt/lib/modules/${KERNEL_VERSION}/pf_ring.ko 
 RUN apk add kmod
 
 RUN depmod -b /opt ${KERNEL_VERSION}

--- a/helm-chart/PF_RING.md
+++ b/helm-chart/PF_RING.md
@@ -39,7 +39,18 @@ The Kernel Module Management controller ([KMM](https://kmm.sigs.k8s.io/documenta
 Prior to choosing a method, it is essential to verify if a PF_RING kernel module is already built for your kernel version. This can be done by running:
 
 ```
+# TODO: develop this command
+# 1. collect list of nodes and theirs kernel verisons
+# 2. download json with available kernel versions
+# 3. compare and provide report
 kubeshark pfring compatibility
+
+# example output
+| node                                          | kernel version                | exists |
+|-----------------------------------------------|-------------------------------|--------|
+| ip-192-168-34-216.us-west-2.compute.internal  | 5.10.198-187.748.amzn2.x86_64 | true   |
+
+Modules for all kernel versions exist: true
 ```
 
 This command checks for the availability of kernel modules for the kernel versions running across all nodes in the Kubernetes cluster.
@@ -126,6 +137,7 @@ PF_RING kernel module compilation can be completed automatically or manually.
 In case your Kubernetes workers run supported Linux distribution, `kubeshark` CLI can be used to build PF_RING module:
 
 ```
+# currently implemented in pf-ring-compiler
 kubeshark pfring compile --target <distro>
 ```
 

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -152,6 +152,7 @@ helm install kubeshark kubeshark/kubeshark \
 | `tap.ingress.annotations`                 | `Ingress` annotations                           | `{}`                                                    |
 | `tap.ipv6`                                | Enable IPv6 support for the front-end                        | `true`                                                  |
 | `tap.debug`                               | Enable debug mode                             | `false`                                                 |
+| `tap.kernelModule.enabled`                    | Use PF_RING kernel module([details](PF_RING.md))      | `true`                                                 |
 | `tap.kernelModule.mode`                    | PF_RING kernel module loading approach([details](PF_RING.md))      | `auto`                                                 |
 | `tap.kernelModule.imageRepoSecret`                    | ImageRepoSecret is an optional secret that is used to pull both the module loader container([details](PF_RING.md))      | ""                                                 |
 | `tap.kernelModule.kernelMappings`                    |List of mappings between kernel version and container loader([details](PF_RING.md))      | `[{'regexp': '.+$', 'containerImage': 'kubehq/pf-ring-module:${KERNEL_FULL_VERSION}'}]`                                                 |

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -94,7 +94,7 @@ For example, change from the default 500Mi to 1Gi:
 ```shell
 --set tap.storageLimit=1Gi
 ```
- 
+
 ## Disabling IPV6
 
 Not all have IPV6 enabled, hence this has to be disabled as follows:
@@ -152,7 +152,7 @@ helm install kubeshark kubeshark/kubeshark \
 | `tap.ingress.annotations`                 | `Ingress` annotations                           | `{}`                                                    |
 | `tap.ipv6`                                | Enable IPv6 support for the front-end                        | `true`                                                  |
 | `tap.debug`                               | Enable debug mode                             | `false`                                                 |
-| `tap.noKernelModule`                      | Do not install `PF_RING` kernel module       | `false`                                                 |
+| `tap.kernelModule`                        | Create `PF_RING` kernel module custom resource      | `false`                                                 |
 | `tap.telemetry.enabled`                   | Enable anonymous usage statistics collection           | `true`                                                  |
 | `logs.file`                               | Logs dump path                      | `""`                                                    |
 | `kube.configPath`                         | Path to the `kubeconfig` file (`$HOME/.kube/config`)            | `""`                                                    |

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -152,7 +152,9 @@ helm install kubeshark kubeshark/kubeshark \
 | `tap.ingress.annotations`                 | `Ingress` annotations                           | `{}`                                                    |
 | `tap.ipv6`                                | Enable IPv6 support for the front-end                        | `true`                                                  |
 | `tap.debug`                               | Enable debug mode                             | `false`                                                 |
-| `tap.kernelModule`                        | Create `PF_RING` kernel module custom resource      | `false`                                                 |
+| `tap.kernelModule.mode`                    | PF_RING kernel module loading approach([details](PF_RING.md))      | `auto`                                                 |
+| `tap.kernelModule.imageRepoSecret`                    | ImageRepoSecret is an optional secret that is used to pull both the module loader container([details](PF_RING.md))      | ""                                                 |
+| `tap.kernelModule.kernelMappings`                    |List of mappings between kernel version and container loader([details](PF_RING.md))      | `[{'regexp': '.+$', 'containerImage': 'kubehq/pf-ring-module:${KERNEL_FULL_VERSION}'}]`                                                 |
 | `tap.telemetry.enabled`                   | Enable anonymous usage statistics collection           | `true`                                                  |
 | `logs.file`                               | Logs dump path                      | `""`                                                    |
 | `kube.configPath`                         | Path to the `kubeconfig` file (`$HOME/.kube/config`)            | `""`                                                    |
@@ -163,3 +165,7 @@ helm install kubeshark kubeshark/kubeshark \
 | `scripting.env`                           | Environment variables for the scripting      | `{}`                                                    |
 | `scripting.source`                        | Source directory of the scripts                | `""`                                                    |
 | `scripting.watchScripts`                  | Enable watch mode for the scripts in source directory          | `true`                                                  |
+
+KernelMapping pairs kernel versions with a
+                            DriverContainer image. Kernel versions can be matched
+                            literally or using a regular expression

--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -25,6 +25,23 @@ spec:
       name: kubeshark-worker-daemon-set
       namespace: kubeshark
     spec:
+      {{ if .Values.tap.kernelModule}}
+      initContainers:
+      - name: wait-for-pf-ring
+        image: alpine:3.18
+        command: ["/bin/sh", "-c"]
+        args:
+        - >
+          while true; do
+            if lsmod | grep -q "pf_ring"; then
+              echo "pf_ring module is loaded.";
+              break;
+            else
+              echo "Waiting for pf_ring module to be loaded...";
+              sleep 5;
+            fi
+          done
+      {{ end }}
       containers:
         - command:
             - ./worker
@@ -37,11 +54,9 @@ spec:
           {{- end }}
             - -procfs
             - /hostproc
+            - -no-kernel-module
           {{- if .Values.tap.debug }}
             - -debug
-          {{- end }}
-          {{- if .Values.tap.noKernelModule }}
-            - -no-kernel-module
           {{- end }}
           image: '{{ .Values.tap.docker.registry }}/worker:{{ not (eq .Values.tap.docker.tag "") | ternary .Values.tap.docker.tag (printf "v%s" .Chart.Version) }}'
           imagePullPolicy: {{ .Values.tap.docker.imagePullPolicy }}
@@ -69,10 +84,6 @@ spec:
                 - NET_RAW
                 # NET_ADMIN is required to listen the network traffic
                 - NET_ADMIN
-                {{- if not .Values.tap.noKernelModule }}
-                # SYS_MODULE is required to install kernel modules
-                - SYS_MODULE
-                {{- end }}
                 {{- if .Values.tap.serviceMesh }}
                 # SYS_ADMIN is required to read /proc/PID/net/ns + to install eBPF programs (kernel < 5.8)
                 - SYS_ADMIN

--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -82,23 +82,13 @@ spec:
           securityContext:
             capabilities:
               add:
-<<<<<<< HEAD
-                # NET_RAW is required to listen the network traffic
-                - NET_RAW
-                # NET_ADMIN is required to listen the network traffic
-                - NET_ADMIN
-                {{- if and (.Values.tap.kernelModule.enabled) (eq .Values.tap.kernelModule.mode "auto") }}
-                # SYS_MODULE is required to install kernel modules
-                - SYS_MODULE
-=======
                 {{- range .Values.tap.capabilities.networkCapture }}
                 {{ print "- " . }}
                 {{- end }}
-                {{- if not .Values.tap.noKernelModule }}
+                {{- if and (.Values.tap.kernelModule.enabled) (eq .Values.tap.kernelModule.mode "auto") }}
                 {{- range .Values.tap.capabilities.kernelModule }}
                 {{ print "- " . }}
                 {{- end }}
->>>>>>> master
                 {{- end }}
                 {{- if .Values.tap.serviceMesh }}
                 {{- range .Values.tap.capabilities.serviceMeshCapture }}

--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -54,7 +54,9 @@ spec:
           {{- end }}
             - -procfs
             - /hostproc
+          {{- if eq .Values.tap.kernelModule.mode "kmm" }}
             - -no-kernel-module
+          {{ end }}
           {{- if .Values.tap.debug }}
             - -debug
           {{- end }}
@@ -84,6 +86,10 @@ spec:
                 - NET_RAW
                 # NET_ADMIN is required to listen the network traffic
                 - NET_ADMIN
+                {{- if eq .Values.tap.kernelModule.mode "auto" }}
+                # SYS_MODULE is required to install kernel modules
+                - SYS_MODULE
+                {{- end }}
                 {{- if .Values.tap.serviceMesh }}
                 # SYS_ADMIN is required to read /proc/PID/net/ns + to install eBPF programs (kernel < 5.8)
                 - SYS_ADMIN

--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -25,7 +25,7 @@ spec:
       name: kubeshark-worker-daemon-set
       namespace: kubeshark
     spec:
-      {{ if .Values.tap.kernelModule}}
+      {{ if and (eq .Values.tap.kernelModule.enabled true) (eq .Values.tap.kernelModule.mode "kmm")}}
       initContainers:
       - name: wait-for-pf-ring
         image: alpine:3.18
@@ -54,7 +54,7 @@ spec:
           {{- end }}
             - -procfs
             - /hostproc
-          {{- if eq .Values.tap.kernelModule.mode "kmm" }}
+          {{- if or (eq .Values.tap.kernelModule.enabled false) (eq .Values.tap.kernelModule.mode "kmm") }}
             - -no-kernel-module
           {{ end }}
           {{- if .Values.tap.debug }}
@@ -86,7 +86,7 @@ spec:
                 - NET_RAW
                 # NET_ADMIN is required to listen the network traffic
                 - NET_ADMIN
-                {{- if eq .Values.tap.kernelModule.mode "auto" }}
+                {{- if and (.Values.tap.kernelModule.enabled) (eq .Values.tap.kernelModule.mode "auto") }}
                 # SYS_MODULE is required to install kernel modules
                 - SYS_MODULE
                 {{- end }}

--- a/helm-chart/templates/15-pf-ring-kernel-module.yaml
+++ b/helm-chart/templates/15-pf-ring-kernel-module.yaml
@@ -24,4 +24,59 @@ spec:
   imageRepoSecret:
     name: {{ .Values.tap.kernelModule.imageRepoSecret }}
   {{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pfring-kmm-status-check-script
+data:
+  check_status.sh: |
+    #!/bin/bash
+
+    timeout=300
+    interval=10
+    elapsed=0
+
+    while [ $elapsed -lt $timeout ]; do
+        desired=$(kubectl get modules pf-ring -o json | jq -r .status.moduleLoader.desiredNumber)
+        available=$(kubectl get modules pf-ring -o json | jq -r .status.moduleLoader.availableNumber)
+
+        echo "Checking dsired and available module load: $desired vs $available"
+
+        if [ "$desired" = "$available" ]; then
+            echo "PF_RING loaded an all nodes."
+            exit 0
+        else
+            sleep $interval
+            elapsed=$((elapsed + interval))
+        fi
+    done
+
+    echo "Timeout reached. PF_RING module didn't reach desired status."
+    exit 1
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pfring-kmm-status-check
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    spec:
+      containers:
+      - name: verify-pfring-kmm-status
+        image: alpine/k8s:1.27.8
+        command: ["/bin/bash", "/scripts/check_status.sh"]
+        volumeMounts:
+        - name: script-volume
+          mountPath: /scripts
+      volumes:
+      - name: script-volume
+        configMap:
+          name: pfring-kmm-status-check-script
+      restartPolicy: Never
 {{- end }}

--- a/helm-chart/templates/15-pf-ring-kernel-module.yaml
+++ b/helm-chart/templates/15-pf-ring-kernel-module.yaml
@@ -42,7 +42,7 @@ data:
         desired=$(kubectl get modules pf-ring -o json | jq -r .status.moduleLoader.desiredNumber)
         available=$(kubectl get modules pf-ring -o json | jq -r .status.moduleLoader.availableNumber)
 
-        echo "Checking dsired and available module load: $desired vs $available"
+        echo "Checking desired and available module load: $desired vs $available"
 
         if [ "$desired" = "$available" ]; then
             echo "PF_RING loaded an all nodes."

--- a/helm-chart/templates/15-pf-ring-kernel-module.yaml
+++ b/helm-chart/templates/15-pf-ring-kernel-module.yaml
@@ -1,5 +1,8 @@
 ---
-{{- if .Values.tap.kernelModule }}
+{{- if not (or (eq .Values.tap.kernelModule.mode "auto") (eq .Values.tap.kernelModule.mode "kmm")) }}
+{{- fail "Invalid value for tap.kernelModule.mode; must be 'auto' or 'kmm'" }}
+{{- end }}
+{{- if eq .Values.tap.kernelModule.mode "kmm" }}
 apiVersion: kmm.sigs.x-k8s.io/v1beta1
 kind: Module
 metadata:
@@ -11,8 +14,14 @@ spec:
         moduleName: pf_ring
         dirName: /opt
       kernelMappings:
-        - regexp: '^.+$'
-          containerImage: 'kubehq/pf-ring-module:${KERNEL_FULL_VERSION}'
+      -
+      {{- range .Values.tap.kernelModule.kernelMappings }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
   selector:
     kubernetes.io/hostname:
+  {{- if ne .Values.tap.kernelModule.imageRepoSecret "" }}
+  imageRepoSecret:
+    name: {{ .Values.tap.kernelModule.imageRepoSecret }}
+  {{- end }}
 {{- end }}

--- a/helm-chart/templates/15-pf-ring-kernel-module.yaml
+++ b/helm-chart/templates/15-pf-ring-kernel-module.yaml
@@ -1,4 +1,5 @@
 ---
+{{- if .Values.tap.kernelModule.enabled }}
 {{- if not (or (eq .Values.tap.kernelModule.mode "auto") (eq .Values.tap.kernelModule.mode "kmm")) }}
 {{- fail "Invalid value for tap.kernelModule.mode; must be 'auto' or 'kmm'" }}
 {{- end }}
@@ -79,4 +80,5 @@ spec:
         configMap:
           name: pfring-kmm-status-check-script
       restartPolicy: Never
+{{- end }}
 {{- end }}

--- a/helm-chart/templates/15-pf-ring-kernel-module.yaml
+++ b/helm-chart/templates/15-pf-ring-kernel-module.yaml
@@ -1,0 +1,18 @@
+---
+{{- if .Values.tap.kernelModule }}
+apiVersion: kmm.sigs.x-k8s.io/v1beta1
+kind: Module
+metadata:
+  name: pf-ring
+spec:
+  moduleLoader:
+    container:
+      modprobe:
+        moduleName: pf_ring
+        dirName: /opt
+      kernelMappings:
+        - regexp: '^.+$'
+          containerImage: 'kubehq/pf-ring-module:${KERNEL_FULL_VERSION}'
+  selector:
+    kubernetes.io/hostname:
+{{- end }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -67,8 +67,7 @@ tap:
     mode: auto
     kernelMappings:
     - regexp: '^.+$'
-      # TODO: replace with kubehq/kubeshark:pf-ring-<kernel-version>?
-      containerImage: 'kubehq/pf-ring-module:${KERNEL_FULL_VERSION}'
+      containerImage: 'kubeshark/pf-ring-module:${KERNEL_FULL_VERSION}'
     imageRepoSecret: ""
   telemetry:
     enabled: true

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -63,7 +63,12 @@ tap:
     annotations: {}
   ipv6: true
   debug: false
-  kernelModule: false
+  kernelModule:
+    mode: auto
+    kernelMappings:
+    - regexp: '^.+$'
+      containerImage: 'kubehq/pf-ring-module:${KERNEL_FULL_VERSION}'
+    imageRepoSecret: ""
   telemetry:
     enabled: true
 logs:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -63,7 +63,7 @@ tap:
     annotations: {}
   ipv6: true
   debug: false
-  noKernelModule: false
+  kernelModule: false
   telemetry:
     enabled: true
 logs:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -67,6 +67,7 @@ tap:
     mode: auto
     kernelMappings:
     - regexp: '^.+$'
+      # TODO: replace with kubehq/kubeshark:pf-ring-<kernel-version>?
       containerImage: 'kubehq/pf-ring-module:${KERNEL_FULL_VERSION}'
     imageRepoSecret: ""
   telemetry:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -64,6 +64,7 @@ tap:
   ipv6: true
   debug: false
   kernelModule:
+    enabled: true
     mode: auto
     kernelMappings:
     - regexp: '^.+$'


### PR DESCRIPTION
Towards https://github.com/kubeshark/kubeshark/issues/1458 and https://github.com/kubeshark/kubeshark/issues/1464

- two modes of running with pf_ring - auto and kmm
- possibility to load pf_ring kernel module via kernel module management controller
- automation for a custom module compilation
- tool to verify compatibility of cluster with pf_ring and build helper

@alongir if we ok with this - then I'll make https://github.com/kubeshark/pf-ring-compiler public