### PR TITLE
goreleaser: Add missing ldflags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,3 +88,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
           VER: ${{ steps.version.outputs.tag }}
           BUILD_TIMESTAMP: ${{ steps.version.outputs.build_timestamp }}
+          GIT_BRANCH: ${{ steps.version.outputs.branch }}
+          COMMIT_HASH: ${{ env.GITHUB_SHA }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,7 @@ builds:
 brews:
   - name: kubeshark
     homepage: https://github.com/kubeshark/kubeshark
-    tap:
+    repository:
       owner: kubeshark
       name: homebrew-kubeshark
     commit_author:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,13 @@
+builds:
+  - id: default
+    ldflags: |
+      -extldflags=-static -s -w
+      -X 'github.com/kubeshark/kubeshark/misc.GitCommitHash={{ .Env.COMMIT_HASH }}'
+      -X 'github.com/kubeshark/kubeshark/misc.Branch={{ .Env.GIT_BRANCH }}'
+      -X 'github.com/kubeshark/kubeshark/misc.BuildTimestamp={{ .Env.BUILD_TIMESTAMP }}'
+      -X 'github.com/kubeshark/kubeshark/misc.Platform={{ .Runtime.Goos }}_{{ .Runtime.Goarch }}'
+      -X 'github.com/kubeshark/kubeshark/misc.Ver={{ .Env.VER }}'
+
 brews:
   - name: kubeshark
     homepage: https://github.com/kubeshark/kubeshark


### PR DESCRIPTION
goreleaser creates binaries without the required ldflags (binaries built with it and added to archives have incorrect version).

This PR adds the same env vars and ldflags that are used in the Makefile to build standalone binaries.

Simulating a build for v52.0.0:

```
$ VER=v52.0.0 BUILD_TIMESTAMP=1703006570 COMMIT_HASH=cc9627c884b34fe145dc8a7aeedb18dca8ae19f4 GIT_BRANCH=master goreleaser build --clean --skip=validate --snapshot
  • starting build...
  • loading                                          path=.goreleaser.yml
  • skipping validate...
  • loading environment variables
  • getting and validating git state
    • ignoring errors because this is a snapshot     error=git doesn't contain any tags. Either add a tag or use --snapshot
    • git state                                      commit=965c7d12ce5775e90a44894f8f861b4225e4c8cc branch=fix/1468 current_tag=v0.0.0 previous_tag=<unknown> dirty=false
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
    • DEPRECATED:  brews.tap  should not be used anymore, check https://goreleaser.com/deprecations#brewstap for more info
  • snapshotting
    • building snapshot...                           version=0.0.0-SNAPSHOT-965c7d12
  • checking distribution directory
  • loading go mod information
  • build prerequisites
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • building binaries
    • building                                       binary=dist/default_windows_386/kubeshark.exe
    • building                                       binary=dist/default_linux_amd64_v1/kubeshark
    • building                                       binary=dist/default_linux_arm64/kubeshark
    • building                                       binary=dist/default_linux_386/kubeshark
    • building                                       binary=dist/default_windows_amd64_v1/kubeshark.exe
    • building                                       binary=dist/default_darwin_arm64/kubeshark
    • building                                       binary=dist/default_windows_arm64/kubeshark.exe
    • building                                       binary=dist/default_darwin_amd64_v1/kubeshark
    • took: 3s
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • you are using deprecated options, check the output above for details
  • build succeeded after 2s
  • thanks for using goreleaser!

$ ./dist/default_linux_amd64_v1/kubeshark version
v52.0.0
```

Fixes #1468