### PR TITLE
Global Filter, escaping doublequotes in strings

### DIFF
--- a/helm-chart/templates/12-config-map.yaml
+++ b/helm-chart/templates/12-config-map.yaml
@@ -16,5 +16,5 @@ data:
     AUTH_APPROVED_TENANTS: '{{ gt (len .Values.tap.auth.approvedTenants) 0 | ternary (join "," .Values.tap.auth.approvedTenants) "" }}'
     TELEMETRY_DISABLED: '{{ not .Values.tap.telemetry.enabled | ternary "true" "" }}'
     REPLAY_DISABLED: '{{ .Values.tap.replayDisabled | ternary "true" "" }}'
-    GLOBAL_FILTER: '{{ .Values.tap.globalFilter }}'
+    GLOBAL_FILTER: "{{ .Values.tap.globalFilter }}"
     TRAFFIC_SAMPLE_RATE: '{{ .Values.tap.trafficSampleRate }}'

--- a/helm-chart/templates/12-config-map.yaml
+++ b/helm-chart/templates/12-config-map.yaml
@@ -16,5 +16,5 @@ data:
     AUTH_APPROVED_TENANTS: '{{ gt (len .Values.tap.auth.approvedTenants) 0 | ternary (join "," .Values.tap.auth.approvedTenants) "" }}'
     TELEMETRY_DISABLED: '{{ not .Values.tap.telemetry.enabled | ternary "true" "" }}'
     REPLAY_DISABLED: '{{ .Values.tap.replayDisabled | ternary "true" "" }}'
-    GLOBAL_FILTER: "{{ .Values.tap.globalFilter }}"
+    GLOBAL_FILTER: {{ include "kubeshark.escapeDoubleQuotes" .Values.tap.globalFilter | quote }}
     TRAFFIC_SAMPLE_RATE: '{{ .Values.tap.trafficSampleRate }}'

--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -48,3 +48,11 @@ Create the name of the service account to use
 {{- define "kubeshark.serviceAccountName" -}}
 {{- printf "%s-service-account" .Release.Name }}
 {{- end }}
+
+{{/*
+Escape double quotes in a string
+*/}}
+{{- define "kubeshark.escapeDoubleQuotes" -}}
+  {{- regexReplaceAll "\"" . "\"" -}}
+{{- end -}}
+


### PR DESCRIPTION
Global filter uses a single quote as opposed to double quote. This limits the use of `'` inside the string as it can not be escaped. When using double quote ("), single quote can be used and double quote can be escaped as part of a string. An example for a Global Filter string: "redact(\"request.headers.Authorization\", \"request.headers['X-Aws-Ec2-Metadata-Token']\")"