### PR TITLE
Add IPC_LOCK capability for tracer

### DIFF
--- a/config/configStruct.go
+++ b/config/configStruct.go
@@ -57,6 +57,8 @@ func CreateDefaultConfig() ConfigStruct {
 					"SYS_RESOURCE",
 					// CHECKPOINT_RESTORE is required to readlink /proc/PID/exe (kernel > 5.9)
 					"CHECKPOINT_RESTORE",
+					// IPC_LOCK is required for ebpf perf rings (kernel > )
+					"IPC_LOCK",
 				},
 			},
 			Auth: configStructs.AuthConfig{

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -104,6 +104,7 @@ tap:
     - SYS_PTRACE
     - SYS_RESOURCE
     - CHECKPOINT_RESTORE
+    - IPC_LOCK
   globalFilter: ""
   metrics:
     port: 49100


### PR DESCRIPTION
during tracer ebpf perfbuf calls mmap(2) is required in some cases

found whet testing https://github.com/kubeshark/tracer/issues/20 on Linux 6.5.0
