### PR TITLE
Template homebrew formulae with proper binaries

### DIFF
--- a/.github/static/kubeshark.rb.tmpl
+++ b/.github/static/kubeshark.rb.tmpl
@@ -1,0 +1,46 @@
+# typed: false
+# frozen_string_literal: true
+
+class Kubeshark < Formula
+  desc ""
+  homepage "https://github.com/kubeshark/kubeshark"
+  version "${CLEAN_VERSION}"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/kubeshark/kubeshark/releases/download/${FULL_VERSION}/kubeshark_darwin_arm64"
+      sha256 "${DARWIN_ARM64_SHA256}"
+
+      def install
+        bin.install "kubeshark_darwin_arm64" => "kubeshark"
+      end
+    end
+    if Hardware::CPU.intel?
+      url "https://github.com/kubeshark/kubeshark/releases/download/${FULL_VERSION}/kubeshark_darwin_amd64"
+      sha256 "${DARWIN_AMD64_SHA256}"
+
+      def install
+        bin.install "kubeshark_darwin_amd64" => "kubeshark"
+      end
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.intel?
+      url "https://github.com/kubeshark/kubeshark/releases/download/${FULL_VERSION}/kubeshark_linux_amd64"
+      sha256 "${LINUX_AMD64_SHA256}"
+
+      def install
+        bin.install "kubeshark_linux_amd64" => "kubeshark"
+      end
+    end
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://github.com/kubeshark/kubeshark/releases/download/${FULL_VERSION}/kubeshark_linux_arm64"
+      sha256 "${LINUX_ARM64_SHA256}"
+
+      def install
+        bin.install "kubeshark_linux_arm64" => "kubeshark"
+      end
+    end
+  end
+end

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,41 +50,33 @@ jobs:
           prerelease: true
           bodyFile: 'bin/README.md'
 
-  brew-tap:
-    name: Create Homebrew formulae
-    runs-on: ubuntu-latest
-    needs: [release]
-    steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          repository: kubeshark/homebrew-kubeshark
+          ssh-key: ${{ secrets.HOMEBREW_SSH_KEY }}
+          path: homebrew-kubeshark
 
-      - name: Version
-        id: version
+      - name: Generate Homebrew formulae
         shell: bash
         run: |
-          {
-            echo "tag=${GITHUB_REF#refs/*/}"
-            echo "build_timestamp=$(date +%s)"
-            echo "branch=${GITHUB_REF#refs/heads/}"
-          } >> "$GITHUB_OUTPUT"
+          export FULL_VERSION=${{ steps.version.outputs.tag }}
+          export CLEAN_VERSION=$(echo $FULL_VERSION | sed 's/^v//')
+          export DARWIN_AMD64_SHA256=$(shasum -a 256 bin/kubeshark_darwin_amd64 | awk '{print $1}')
+          export DARWIN_ARM64_SHA256=$(shasum -a 256 bin/kubeshark_darwin_arm64 | awk '{print $1}')
+          export LINUX_AMD64_SHA256=$(shasum -a 256 bin/kubeshark_linux_amd64 | awk '{print $1}')
+          export LINUX_ARM64_SHA256=$(shasum -a 256 bin/kubeshark_linux_arm64 | awk '{print $1}')
+          envsubst < .github/static/kubeshark.rb.tmpl > homebrew-kubeshark/kubeshark.rb
 
-      - name: Fetch all tags
-        run: git fetch --force --tags
+          cat homebrew-kubeshark/kubeshark.rb
 
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version-file: 'go.mod'
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
-        with:
-          distribution: goreleaser
-          version: ${{ env.GITHUB_REF_NAME }}
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.HOMEBREW_TOKEN }}
-          VER: ${{ steps.version.outputs.tag }}
-          BUILD_TIMESTAMP: ${{ steps.version.outputs.build_timestamp }}
+      - name: Commit and push Homebrew formulae
+        working-directory: homebrew-kubeshark
+        run: |
+          git config --global user.email "bot@kubeshark.io"
+          git config --global user.name "Kubeshark Bot"
+          git add kubeshark.rb
+          git commit -m "Release ${{ steps.version.outputs.tag }}"
+          git push
+  


### PR DESCRIPTION
Towards https://github.com/kubeshark/kubeshark/issues/1488 and https://github.com/kubeshark/kubeshark/issues/1345

For now we're releasing two pairs of artifacts per platform: one compiled with make and another (binary) one with goreleaser (tar.gz). If I'm not mistaken, we do gorelease only to have brew tap updated automatically. But gorelease binaries don't have proper `kubeshark version` output as they are compiled without make and `VER=` variable set.

This PR:
1. Removes goreleaser job
2. Adds homebrew formulae template which is rendered with proper binary URLs and sha256 during release.

TODO:
- add deployment key into https://github.com/kubeshark/homebrew-kubeshark repo with write access
- add secret.HOMEBREW_SSH_KEY with private key part of deployment key

This approach was tested with canary repos:
1. https://github.com/kubeshark/kubeshark-canary/actions/runs/8020772082 - here is release action in action
2. here is tap repo commit updated with action from previous step https://github.com/kubeshark/homebrew-kubeshark-canary/commit/1d79ec0bedc65a055f03a64042300892dc2a772d
 