### PR TITLE
Add build-brew target for makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,15 @@ build-base: ## Build binary (select the platform via GOOS / GOARCH env variables
 					-o bin/kubeshark_$(SUFFIX) kubeshark.go && \
 	cd bin && shasum -a 256 kubeshark_${SUFFIX} > kubeshark_${SUFFIX}.sha256
 
+build-brew: ## Build binary for brew/core CI
+	go build ${GCLFAGS} -ldflags="${LDFLAGS_EXT} \
+					-X 'github.com/kubeshark/kubeshark/misc.GitCommitHash=$(COMMIT_HASH)' \
+					-X 'github.com/kubeshark/kubeshark/misc.Branch=$(GIT_BRANCH)' \
+					-X 'github.com/kubeshark/kubeshark/misc.BuildTimestamp=$(BUILD_TIMESTAMP)' \
+					-X 'github.com/kubeshark/kubeshark/misc.Platform=$(SUFFIX)' \
+					-X 'github.com/kubeshark/kubeshark/misc.Ver=$(VER)'" \
+					-o kubeshark kubeshark.go
+
 build-all: ## Build for all supported platforms.
 	export CGO_ENABLED=0
 	echo "Compiling for every OS and Platform" && \


### PR DESCRIPTION
Towards https://github.com/kubeshark/kubeshark/issues/1488

This is needed for adding kubeshark into brew/core repository.
Brew bot will run then formula like

```
  def install
    system "make", "build-brew", "VER=#{version}"
    bin.install "kubeshark"
  end
```

Operating systems and architectures are provided by bot, so we need only run build on whatever env is provided by brew/core CI and run install.
This target won't be used anywhere else