### PR TITLE
Add namespace prefix to cluster scope resources

### DIFF
--- a/helm-chart/templates/02-cluster-role.yaml
+++ b/helm-chart/templates/02-cluster-role.yaml
@@ -8,7 +8,7 @@ metadata:
   {{- if .Values.tap.annotations }}
     {{- toYaml .Values.tap.annotations | nindent 4 }}
   {{- end }}
-  name: kubeshark-cluster-role
+  name: kubeshark-cluster-role-{{ .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups:

--- a/helm-chart/templates/03-cluster-role-binding.yaml
+++ b/helm-chart/templates/03-cluster-role-binding.yaml
@@ -8,12 +8,12 @@ metadata:
   {{- if .Values.tap.annotations }}
     {{- toYaml .Values.tap.annotations | nindent 4 }}
   {{- end }}
-  name: kubeshark-cluster-role-binding
+  name: kubeshark-cluster-role-binding-{{ .Release.Namespace }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kubeshark-cluster-role
+  name: kubeshark-cluster-role-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "kubeshark.serviceAccountName" . }}


### PR DESCRIPTION
Towards https://github.com/kubeshark/kubeshark/issues/1481

I've used these values to be able to run two instances of kubeshark

values-default.yaml
```
tap:
  proxy:
    worker:
      srvPort: 30001
  metrics:
    port: 49100
```
install: `helm upgrade --install kubeshark helm-chart --set tap.docker.tag=canary --values values-default.yaml --namespace default`

values-vol.yaml
```
tap:
  proxy:
    worker:
      srvPort: 30002
  metrics:
    port: 49101%
```
 
install: `kubectl create namespace vol; helm upgrade --install kubeshark helm-chart --set tap.docker.tag=canary --values values-vol --namespace vol`

Metrics also work out of the box, the only think to get result for proper instance, query should include instance port

e.g.
for default namespace:
```
kubeshark_matched_pairs_total{instance=~".*:49100"}
```

for vol namespace
```
kubeshark_matched_pairs_total{instance=~".*:49101"}
```