### PR TITLE
fix: fix the asset name of the checksum file for windows/amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,12 @@ build-brew: ## Build binary for brew/core CI
 					-X 'github.com/kubeshark/kubeshark/misc.Ver=$(VER)'" \
 					-o kubeshark kubeshark.go
 
+build-windows-amd64:
+	$(MAKE) build GOOS=windows GOARCH=amd64 && \
+	mv ./bin/kubeshark_windows_amd64 ./bin/kubeshark.exe && \
+	rm bin/kubeshark_windows_amd64.sha256 && \
+	cd bin && shasum -a 256 kubeshark.exe > kubeshark.exe.sha256
+
 build-all: ## Build for all supported platforms.
 	export CGO_ENABLED=0
 	echo "Compiling for every OS and Platform" && \
@@ -57,8 +63,7 @@ build-all: ## Build for all supported platforms.
 	$(MAKE) build GOOS=linux GOARCH=arm64 && \
 	$(MAKE) build GOOS=darwin GOARCH=amd64 && \
 	$(MAKE) build GOOS=darwin GOARCH=arm64 && \
-	$(MAKE) build GOOS=windows GOARCH=amd64 && \
-	mv ./bin/kubeshark_windows_amd64 ./bin/kubeshark.exe && \
+	$(MAKE) build-windows-amd64 && \
 	echo "---------" && \
 	find ./bin -ls
 


### PR DESCRIPTION
Close #1510

Pre-built binaries and checksum files are released at GitHub Releases.

https://github.com/kubeshark/kubeshark/releases

But checksum files for windows/amd64 have the following issues.

kubeshark.exe
kubeshark_windows_amd64.sha256

- The executable file name and the checksum file name don't conform to the naming convention
- We can't verify the pre-built binaries with checksum files because the pre-built binary name is different from the actual binary name

```console
$ cat kubeshark_windows_amd64.sha256
ea8fffa952bc8047f493469d024887ed80f966c0d74cf5fb039ea12f71174629  kubeshark_windows_amd64
```

```console
$ sha256sum -c kubeshark_windows_amd64.sha256
sha256sum: kubeshark_windows_amd64: No such file or directory
kubeshark_windows_amd64: FAILED open or read
sha256sum: WARNING: 1 listed file could not be read
```

The cause of these issues is pre-built binaries were renamed after checksum files were generated.

https://github.com/kubeshark/kubeshark/blob/b125860d068f41fd7410c4ca24a88f0278b52864/Makefile#L41
https://github.com/kubeshark/kubeshark/blob/b125860d068f41fd7410c4ca24a88f0278b52864/Makefile#L61

This pull request resolves the issue by generating the checksum file after renaming the pre-built binary.

## Test

I ran `make build-all` and confirmed the checksum file is generated as expected on my laptop.

```console
$ make build-all
$ cd bin
$ find . -name '*.sha256' | xargs -n 1 sha256sum -c
kubeshark_darwin_arm64: OK
kubeshark_linux_arm64: OK
kubeshark_darwin_amd64: OK
kubeshark_linux_amd64: OK
kubeshark.exe: OK
```

<details>
<summary>$ make build-all</summary>

```
export CGO_ENABLED=0
echo "Compiling for every OS and Platform" && \
	mkdir -p bin && sed s/_VER_/0.0.0/g RELEASE.md.TEMPLATE >  bin/README.md && \
	/Library/Developer/CommandLineTools/usr/bin/make build GOOS=linux GOARCH=amd64 && \
	/Library/Developer/CommandLineTools/usr/bin/make build GOOS=linux GOARCH=arm64 && \
	/Library/Developer/CommandLineTools/usr/bin/make build GOOS=darwin GOARCH=amd64 && \
	/Library/Developer/CommandLineTools/usr/bin/make build GOOS=darwin GOARCH=arm64 && \
	/Library/Developer/CommandLineTools/usr/bin/make build-windows-amd64 && \
	echo "---------" && \
	find ./bin -ls
Compiling for every OS and Platform
export CGO_ENABLED=0
export LDFLAGS_EXT='-extldflags=-static -s -w'
/Library/Developer/CommandLineTools/usr/bin/make build-base
go build  -ldflags=" \
					-X 'github.com/kubeshark/kubeshark/misc.GitCommitHash=b125860d068f41fd7410c4ca24a88f0278b52864' \
					-X 'github.com/kubeshark/kubeshark/misc.Branch=master' \
					-X 'github.com/kubeshark/kubeshark/misc.BuildTimestamp=1709165239' \
					-X 'github.com/kubeshark/kubeshark/misc.Platform=linux_amd64' \
					-X 'github.com/kubeshark/kubeshark/misc.Ver=0.0.0'" \
					-o bin/kubeshark_linux_amd64 kubeshark.go && \
	cd bin && shasum -a 256 kubeshark_linux_amd64 > kubeshark_linux_amd64.sha256
go: downloading github.com/prometheus/procfs v0.10.1
export CGO_ENABLED=0
export LDFLAGS_EXT='-extldflags=-static -s -w'
/Library/Developer/CommandLineTools/usr/bin/make build-base
go build  -ldflags=" \
					-X 'github.com/kubeshark/kubeshark/misc.GitCommitHash=b125860d068f41fd7410c4ca24a88f0278b52864' \
					-X 'github.com/kubeshark/kubeshark/misc.Branch=master' \
					-X 'github.com/kubeshark/kubeshark/misc.BuildTimestamp=1709165252' \
					-X 'github.com/kubeshark/kubeshark/misc.Platform=linux_arm64' \
					-X 'github.com/kubeshark/kubeshark/misc.Ver=0.0.0'" \
					-o bin/kubeshark_linux_arm64 kubeshark.go && \
	cd bin && shasum -a 256 kubeshark_linux_arm64 > kubeshark_linux_arm64.sha256
export CGO_ENABLED=0
export LDFLAGS_EXT='-extldflags=-static -s -w'
/Library/Developer/CommandLineTools/usr/bin/make build-base
go build  -ldflags=" \
					-X 'github.com/kubeshark/kubeshark/misc.GitCommitHash=b125860d068f41fd7410c4ca24a88f0278b52864' \
					-X 'github.com/kubeshark/kubeshark/misc.Branch=master' \
					-X 'github.com/kubeshark/kubeshark/misc.BuildTimestamp=1709165265' \
					-X 'github.com/kubeshark/kubeshark/misc.Platform=darwin_amd64' \
					-X 'github.com/kubeshark/kubeshark/misc.Ver=0.0.0'" \
					-o bin/kubeshark_darwin_amd64 kubeshark.go && \
	cd bin && shasum -a 256 kubeshark_darwin_amd64 > kubeshark_darwin_amd64.sha256
export CGO_ENABLED=0
export LDFLAGS_EXT='-extldflags=-static -s -w'
/Library/Developer/CommandLineTools/usr/bin/make build-base
go build  -ldflags=" \
					-X 'github.com/kubeshark/kubeshark/misc.GitCommitHash=b125860d068f41fd7410c4ca24a88f0278b52864' \
					-X 'github.com/kubeshark/kubeshark/misc.Branch=master' \
					-X 'github.com/kubeshark/kubeshark/misc.BuildTimestamp=1709165277' \
					-X 'github.com/kubeshark/kubeshark/misc.Platform=darwin_arm64' \
					-X 'github.com/kubeshark/kubeshark/misc.Ver=0.0.0'" \
					-o bin/kubeshark_darwin_arm64 kubeshark.go && \
	cd bin && shasum -a 256 kubeshark_darwin_arm64 > kubeshark_darwin_arm64.sha256
/Library/Developer/CommandLineTools/usr/bin/make build GOOS=windows GOARCH=amd64 && \
	mv ./bin/kubeshark_windows_amd64 ./bin/kubeshark.exe && \
	rm bin/kubeshark_windows_amd64.sha256 && \
	cd bin && shasum -a 256 kubeshark.exe > kubeshark.exe.sha256
export CGO_ENABLED=0
export LDFLAGS_EXT='-extldflags=-static -s -w'
/Library/Developer/CommandLineTools/usr/bin/make build-base
go build  -ldflags=" \
					-X 'github.com/kubeshark/kubeshark/misc.GitCommitHash=b125860d068f41fd7410c4ca24a88f0278b52864' \
					-X 'github.com/kubeshark/kubeshark/misc.Branch=master' \
					-X 'github.com/kubeshark/kubeshark/misc.BuildTimestamp=1709165294' \
					-X 'github.com/kubeshark/kubeshark/misc.Platform=windows_amd64' \
					-X 'github.com/kubeshark/kubeshark/misc.Ver=0.0.0'" \
					-o bin/kubeshark_windows_amd64 kubeshark.go && \
	cd bin && shasum -a 256 kubeshark_windows_amd64 > kubeshark_windows_amd64.sha256
---------
3247578        0 drwxr-xr-x   13 shunsukesuzuki   staff                 416  2 29 09:08 ./bin
3275558        8 -rw-r--r--    1 shunsukesuzuki   staff                  89  2 29 09:08 ./bin/kubeshark_darwin_arm64.sha256
3262424        8 -rw-r--r--    1 shunsukesuzuki   staff                  88  2 29 09:07 ./bin/kubeshark_linux_arm64.sha256
3262421   143752 -rwxr-xr-x    1 shunsukesuzuki   staff            73600651  2 29 09:07 ./bin/kubeshark_linux_arm64
3269568   149472 -rwxr-xr-x    1 shunsukesuzuki   staff            76529344  2 29 09:07 ./bin/kubeshark_darwin_amd64
3247579        8 -rw-r--r--    1 shunsukesuzuki   staff                1078  2 29 09:07 ./bin/README.md
3255238   148240 -rwxr-xr-x    1 shunsukesuzuki   staff            75895621  2 29 09:07 ./bin/kubeshark_linux_amd64
3275579   150248 -rwxr-xr-x    1 shunsukesuzuki   staff            76923904  2 29 09:08 ./bin/kubeshark.exe
3269572        8 -rw-r--r--    1 shunsukesuzuki   staff                  89  2 29 09:07 ./bin/kubeshark_darwin_amd64.sha256
3255262        8 -rw-r--r--    1 shunsukesuzuki   staff                  88  2 29 09:07 ./bin/kubeshark_linux_amd64.sha256
3275587        8 -rw-r--r--    1 shunsukesuzuki   staff                  80  2 29 09:08 ./bin/kubeshark.exe.sha256
3275553   175272 -rwxr-xr-x    1 shunsukesuzuki   staff            85033986  2 29 09:08 ./bin/kubeshark_darwin_arm64
```

</details>