### PR TITLE
Add kubeshark fork to use for homebrew release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
         with:
           # A PR will be sent to github.com/Homebrew/homebrew-core to update this formula:
           formula-name: kubeshark
+          push-to: kubeshark/homebrew-core
         env:
           COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}
 


### PR DESCRIPTION
By default commiter token would use personal fork, but in this case we want to use kubeshark fork https://github.com/kubeshark/homebrew-core