### PR TITLE
🐛 Fix front nginx and network policies ports

### DIFF
--- a/helm-chart/templates/11-nginx-config-map.yaml
+++ b/helm-chart/templates/11-nginx-config-map.yaml
@@ -9,9 +9,9 @@ metadata:
 data:
   default.conf: |
     server {
-      listen 80;
+      listen 8080;
 {{- if .Values.tap.ipv6 }}
-      listen [::]:80;
+      listen [::]:8080;
 {{- end }}
       access_log /dev/stdout;
       error_log /dev/stdout;

--- a/helm-chart/templates/16-network-policies.yaml
+++ b/helm-chart/templates/16-network-policies.yaml
@@ -13,7 +13,7 @@ spec:
   ingress:
     - ports:
         - protocol: TCP
-          port: 80
+          port: 8080
   egress:
     - {}
 ---
@@ -32,7 +32,7 @@ spec:
   ingress:
     - ports:
         - protocol: TCP
-          port: 80
+          port: 8080
   egress:
     - {}
 ---


### PR DESCRIPTION
**In addition to:**
https://github.com/kubeshark/kubeshark/pull/1514

**Fixes issue:**
```
 Warning  Unhealthy  84s (x6 over 91s)  kubelet            Liveness probe failed: dial tcp 10.1.221.106:8080: connect: connection refused
 Warning  Unhealthy  84s (x8 over 91s)  kubelet            Readiness probe failed: dial tcp 10.1.221.106:8080: connect: connection refused
 Normal   Killing    84s (x2 over 89s)  kubelet            Container kubeshark-front failed liveness probe, will be restarted
```