### PR TITLE
add net capabilities for tracer

### DIFF
--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -177,6 +177,9 @@ spec:
                 {{- range .Values.tap.capabilities.ebpfCapture }}
                 {{ print "- " . }}
                 {{- end }}
+                {{- range .Values.tap.capabilities.networkCapture }}
+                {{ print "- " . }}
+                {{- end }}
               drop:
                 - ALL
           volumeMounts:


### PR DESCRIPTION
after https://github.com/kubeshark/tracer/pull/50 tracers operates with netlink and requires network capture capabilities enabled