### PR TITLE
as eBPF is a significant feature that can impact many users, this PR is meant

### DIFF
--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -62,6 +62,9 @@ spec:
           {{- if .Values.tap.kernelModule.enabled }}
             - -kernel-module
           {{- end }}
+          {{- if ne .Values.tap.packetCapture "ebpf" }}
+            - -disable-ebpf
+          {{- end }}
           {{- if .Values.tap.debug }}
             - -debug
             - -dumptracer


### PR DESCRIPTION
to provide it NOT as the default option, but require an explicit indication
to use it. To use eBPF instead of AF-PACKET or PF-RING, use:
--set tap.packetCapture=ebpf