### PR TITLE
Update 14-openshift-security-context-constraints.yaml

### DIFF
--- a/helm-chart/templates/14-openshift-security-context-constraints.yaml
+++ b/helm-chart/templates/14-openshift-security-context-constraints.yaml
@@ -28,6 +28,7 @@ allowedCapabilities:
   - DAC_OVERRIDE
   - SYS_RESOURCE
   - SYS_MODULE
+  - IPC_LOCK
 runAsUser:
   type: RunAsAny
 fsGroup:


### PR DESCRIPTION
Add `IPC_LOCK` to `allowedCapabilities` otherwise kubeshark-worker-daemon-set will not deploy.