### PR TITLE
Use eBPF as a traffic capture source by default if cgroup V2 is enabled.

### DIFF
--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -62,9 +62,6 @@ spec:
           {{- if .Values.tap.kernelModule.enabled }}
             - -kernel-module
           {{- end }}
-          {{- if ne .Values.tap.packetCapture "ebpf" }}
-            - -disable-ebpf
-          {{- end }}
           {{- if .Values.tap.debug }}
             - -debug
             - -dumptracer
@@ -154,9 +151,6 @@ spec:
             - ./tracer
             - -procfs
             - /hostproc
-          {{- if ne .Values.tap.packetCapture "ebpf" }}
-            - -disable-ebpf
-          {{- end }}
           {{- if .Values.tap.debug }}
             - -debug
           {{- end }}


### PR DESCRIPTION
This behavior can be reversed by setting the `tap.packetCapture`
to a specific source or manually adding the command line property:
`-disable-ebpf` to both the `worker` and the `tracer`