### PR TITLE
Add /etc/os-release for tracer sysevents

### DIFF
--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -197,6 +197,9 @@ spec:
               readOnly: true
             - mountPath: /app/data
               name: data
+            - mountPath: /etc/os-release
+              name: os-release
+              readOnly: true
       {{- end }}
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -226,6 +229,9 @@ spec:
         - name: lib-modules
           hostPath:
             path: /lib/modules
+        - hostPath:
+            path: /etc/os-release
+          name: os-release
         - name: data
 {{- if .Values.tap.persistentStorage }}
           persistentVolumeClaim:

--- a/manifests/complete.yaml
+++ b/manifests/complete.yaml
@@ -569,6 +569,9 @@ spec:
               readOnly: true
             - mountPath: /app/data
               name: data
+            - mountPath: /etc/os-release
+              name: os-release
+              readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       serviceAccountName: kubeshark-service-account
@@ -600,6 +603,9 @@ spec:
         - name: data
           emptyDir:
             sizeLimit: 500Mi
+        - hostPath:
+            path: /etc/os-release
+          name: os-release
 ---
 # Source: kubeshark/templates/04-hub-deployment.yaml
 apiVersion: apps/v1


### PR DESCRIPTION
Access to /etc/os-release is required in tracer to enable syscalls 