### PR TITLE
Remove obsolete dumptracer worker option

### DIFF
--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -69,8 +69,6 @@ spec:
             - '{{ .Values.tap.misc.resolutionStrategy }}'
           {{- if .Values.tap.debug }}
             - -debug
-            - -dumptracer
-            - "100000000"
           {{- end }}
         {{- if .Values.tap.docker.overrideTag.worker }}
           image: '{{ .Values.tap.docker.registry }}/worker:{{ .Values.tap.docker.overrideTag.worker }}'


### PR DESCRIPTION
dumptracer doesn't exist in the worker anymore, it been replaced with ksdump which is always on.