### PR TITLE
Slow start

### DIFF
--- a/config/configStruct.go
+++ b/config/configStruct.go
@@ -16,9 +16,6 @@ const (
 func CreateDefaultConfig() ConfigStruct {
 	return ConfigStruct{
 		Tap: configStructs.TapConfig{
-			ExcludedNamespaces: []string{
-				"kube-system",
-			},
 			NodeSelectorTerms: []v1.NodeSelectorTerm{
 				{
 					MatchExpressions: []v1.NodeSelectorRequirement{

--- a/config/configStruct.go
+++ b/config/configStruct.go
@@ -16,9 +16,9 @@ const (
 func CreateDefaultConfig() ConfigStruct {
 	return ConfigStruct{
 		Tap: configStructs.TapConfig{
-			// ExcludedNamespaces: []string{
-			// 	"kube-system",
-			// },
+			ExcludedNamespaces: []string{
+				"kube-system",
+			},
 			NodeSelectorTerms: []v1.NodeSelectorTerm{
 				{
 					MatchExpressions: []v1.NodeSelectorRequirement{

--- a/config/configStruct.go
+++ b/config/configStruct.go
@@ -16,9 +16,9 @@ const (
 func CreateDefaultConfig() ConfigStruct {
 	return ConfigStruct{
 		Tap: configStructs.TapConfig{
-			ExcludedNamespaces: []string{
-				"kube-system",
-			},
+			// ExcludedNamespaces: []string{
+			// 	"kube-system",
+			// },
 			NodeSelectorTerms: []v1.NodeSelectorTerm{
 				{
 					MatchExpressions: []v1.NodeSelectorRequirement{

--- a/config/configStructs/tapConfig.go
+++ b/config/configStructs/tapConfig.go
@@ -167,7 +167,7 @@ type TapConfig struct {
 	Namespaces                   []string              `yaml:"namespaces" json:"namespaces" default:"[]"`
 	ExcludedNamespaces           []string              `yaml:"excludedNamespaces" json:"excludedNamespaces" default:"[]"`
 	BpfOverride                  string                `yaml:"bpfOverride" json:"bpfOverride" default:""`
-	Stopped                      bool                  `yaml:"stopped" json:"stopped" default:"false"`
+	Stopped                      bool                  `yaml:"stopped" json:"stopped" default:"true"`
 	Release                      ReleaseConfig         `yaml:"release" json:"release"`
 	PersistentStorage            bool                  `yaml:"persistentStorage" json:"persistentStorage" default:"false"`
 	PersistentStorageStatic      bool                  `yaml:"persistentStorageStatic" json:"persistentStorageStatic" default:"false"`

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -125,6 +125,7 @@ Please refer to [metrics](./metrics.md) documentation for details.
 | `tap.proxy.front.port`                    | Front-facing service port                     | `8899`                                                  |
 | `tap.proxy.host`                          | Proxy server's IP                                   | `127.0.0.1`                                             |
 | `tap.namespaces`                          | List of namespaces for the traffic capture                 | `[]`                                                    |
+| `tap.excludedNamespaces`                  | List of namespaces to explicitly exclude                 | `[]`                                                    |
 | `tap.release.repo`                        | URL of the Helm chart repository             | `https://helm.kubeshark.co`                             |
 | `tap.release.name`                        | Helm release name                          | `kubeshark`                                             |
 | `tap.release.namespace`                   | Helm release namespace                | `default`                                               |

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -172,6 +172,7 @@ Please refer to [metrics](./metrics.md) documentation for details.
 | `tap.defaultFilter`                       | Sets the default dashboard KFL filter (e.g. `http`)        | `""`                                                  |
 | `tap.globalFilter`                        | Prepends to any KFL filter and can be used to limit what is visible in the dashboard. For example, `redact("request.headers.Authorization")` will redact the appropriate field. Another example `!dns` will not show any DNS traffic.      | `""`                                        |
 | `tap.metrics.port`                  | Pod port used to expose Prometheus metrics          | `49100`                                                  |
+| `tap.stopped`                             | A flag indicating whether to start Kubeshark with traffic processing stopped resulting in almost no resource consumption (e.g. Kubeshark is dormant). This property can be dynamically control via the dashboard.         | `true`                                                  |
 | `logs.file`                               | Logs dump path                      | `""`                                                    |
 | `kube.configPath`                         | Path to the `kubeconfig` file (`$HOME/.kube/config`)            | `""`                                                    |
 | `kube.context`                            | Kubernetes context to use for the deployment  | `""`                                                    |

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -18,10 +18,9 @@ tap:
     host: 127.0.0.1
   regex: .*
   namespaces: []
-  excludedNamespaces:
-  - kube-system
+  excludedNamespaces: []
   bpfOverride: ""
-  stopped: false
+  stopped: true
   release:
     repo: https://helm.kubeshark.co
     name: kubeshark


### PR DESCRIPTION
With the new addition of `tap.stopped` flag, the default value is set to true, causing Kubeshark to start with traffic capture disabled. Users can start traffic capture once they start the dashboard.