### PR TITLE
Disable TCP dissector by default

### DIFF
--- a/config/configStruct.go
+++ b/config/configStruct.go
@@ -82,7 +82,7 @@ func CreateDefaultConfig() ConfigStruct {
 				"redis",
 				"sctp",
 				"syscall",
-				"tcp",
+				// "tcp",
 				"ws",
 			},
 		},


### PR DESCRIPTION
TCP dissector can be added as a helm value. This dissector shouldn't be used in production clusters, as enabling this dissector will consume enormous amounts of CPU and memory.

TODO: Have the TCP dissector adhere to pod targeting rules.