### PR TITLE
Use major version as containers tag

### DIFF
--- a/config/configStructs/tapConfig.go
+++ b/config/configStructs/tapConfig.go
@@ -89,6 +89,7 @@ type OverrideTagConfig struct {
 type DockerConfig struct {
 	Registry         string            `yaml:"registry" json:"registry" default:"docker.io/kubeshark"`
 	Tag              string            `yaml:"tag" json:"tag" default:""`
+	TagLocked        bool              `yaml:"tagLocked" json:"tagLocked" default:"true"`
 	ImagePullPolicy  string            `yaml:"imagePullPolicy" json:"imagePullPolicy" default:"Always"`
 	ImagePullSecrets []string          `yaml:"imagePullSecrets" json:"imagePullSecrets"`
 	OverrideTag      OverrideTagConfig `yaml:"overrideTag" json:"overrideTag"`

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -117,6 +117,7 @@ Please refer to [metrics](./metrics.md) documentation for details.
 |-------------------------------------------|-----------------------------------------------|---------------------------------------------------------|
 | `tap.docker.registry`                     | Docker registry to pull from                           | `docker.io/kubeshark`                                   |
 | `tap.docker.tag`                          | Tag of the Docker images                              | `latest`                                                |
+| `tap.docker.tagLocked`                    | If `false` - use latest minor tag             | `true`                                                  |
 | `tap.docker.imagePullPolicy`              | Kubernetes image pull policy                  | `Always`                                                |
 | `tap.docker.imagePullSecrets`             | Kubernetes secrets to pull the images      | `[]`                                                    |
 | `tap.proxy.worker.srvPort`                | Worker server port                           | `30001`                                                  |

--- a/helm-chart/templates/04-hub-deployment.yaml
+++ b/helm-chart/templates/04-hub-deployment.yaml
@@ -48,7 +48,7 @@ spec:
         {{- if .Values.tap.docker.overrideTag.hub }}
           image: '{{ .Values.tap.docker.registry }}/hub:{{ .Values.tap.docker.overrideTag.hub }}'
         {{ else }}
-          image: '{{ .Values.tap.docker.registry }}/hub:{{ not (eq .Values.tap.docker.tag "") | ternary .Values.tap.docker.tag (printf "v%s" .Chart.Version) }}'
+          image: '{{ .Values.tap.docker.registry }}/hub:{{ not (eq .Values.tap.docker.tag "") | ternary .Values.tap.docker.tag (include "kubeshark.defaultVersion" .) }}'
         {{- end }}
           imagePullPolicy: {{ .Values.tap.docker.imagePullPolicy }}
           readinessProbe:

--- a/helm-chart/templates/06-front-deployment.yaml
+++ b/helm-chart/templates/06-front-deployment.yaml
@@ -65,7 +65,7 @@ spec:
         {{- if .Values.tap.docker.overrideTag.front }}
           image: '{{ .Values.tap.docker.registry }}/front:{{ .Values.tap.docker.overrideTag.front }}'
         {{ else }}
-          image: '{{ .Values.tap.docker.registry }}/front:{{ not (eq .Values.tap.docker.tag "") | ternary .Values.tap.docker.tag (printf "v%s" .Chart.Version) }}'
+          image: '{{ .Values.tap.docker.registry }}/front:{{ not (eq .Values.tap.docker.tag "") | ternary .Values.tap.docker.tag (include "kubeshark.defaultVersion" .) }}'
         {{- end }}
           imagePullPolicy: {{ .Values.tap.docker.imagePullPolicy }}
           name: kubeshark-front

--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -73,7 +73,7 @@ spec:
         {{- if .Values.tap.docker.overrideTag.worker }}
           image: '{{ .Values.tap.docker.registry }}/worker:{{ .Values.tap.docker.overrideTag.worker }}{{ include "kubeshark.dockerTagDebugVersion" . }}'
         {{ else }}
-          image: '{{ .Values.tap.docker.registry }}/worker:{{ not (eq .Values.tap.docker.tag "") | ternary .Values.tap.docker.tag (printf "v%s" .Chart.Version) }}{{ include "kubeshark.dockerTagDebugVersion" . }}'
+          image: '{{ .Values.tap.docker.registry }}/worker:{{ not (eq .Values.tap.docker.tag "") | ternary .Values.tap.docker.tag (include "kubeshark.defaultVersion" .) }}{{ include "kubeshark.dockerTagDebugVersion" . }}'
         {{- end }}
           imagePullPolicy: {{ .Values.tap.docker.imagePullPolicy }}
           name: sniffer
@@ -176,7 +176,7 @@ spec:
         {{- if .Values.tap.docker.overrideTag.worker }}
           image: '{{ .Values.tap.docker.registry }}/worker:{{ .Values.tap.docker.overrideTag.worker }}{{ include "kubeshark.dockerTagDebugVersion" . }}'
         {{ else }}
-          image: '{{ .Values.tap.docker.registry }}/worker:{{ not (eq .Values.tap.docker.tag "") | ternary .Values.tap.docker.tag (printf "v%s" .Chart.Version) }}{{ include "kubeshark.dockerTagDebugVersion" . }}'
+          image: '{{ .Values.tap.docker.registry }}/worker:{{ not (eq .Values.tap.docker.tag "") | ternary .Values.tap.docker.tag (include "kubeshark.defaultVersion" .) }}{{ include "kubeshark.dockerTagDebugVersion" . }}'
         {{- end }}
           imagePullPolicy: {{ .Values.tap.docker.imagePullPolicy }}
           name: tracer

--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -62,3 +62,14 @@ Define debug docker tag suffix
 {{- define "kubeshark.dockerTagDebugVersion" -}}
 {{- .Values.tap.misc.profile | ternary "-debug" "" }}
 {{- end -}}
+
+{{/*
+Create docker tag default version
+*/}}
+{{- define "kubeshark.defaultVersion" -}}
+{{- $defaultVersion := (printf "v%s" .Chart.Version) -}}
+{{- if not .Values.tap.docker.tagLocked }}
+  {{- $defaultVersion = regexReplaceAll "^([^.]+\\.[^.]+).*" $defaultVersion "$1" -}}
+{{- end }}
+{{- $defaultVersion }}
+{{- end -}}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -2,6 +2,7 @@ tap:
   docker:
     registry: docker.io/kubeshark
     tag: ""
+    tagLocked: true
     imagePullPolicy: Always
     imagePullSecrets: []
     overrideTag:
@@ -55,6 +56,7 @@ tap:
         memory: 50Mi
   serviceMesh: true
   tls: true
+  disableTlsLog: false
   packetCapture: best
   ignoreTainted: false
   labels: {}


### PR DESCRIPTION
Towards https://github.com/kubeshark/devops/issues/12

By default everything stays the same.
But if we set tagLocked=false, then instead of full version, only minor version will be used. Eg.. v52.3 for any v52.3.X.
If tag is set explicitly via tap.docker.tag - it will override any option no matter what's the value of tagLocked