### PR TITLE
Calculate sentry based on internet connectivity and telemetry

### DIFF
--- a/helm-chart/templates/04-hub-deployment.yaml
+++ b/helm-chart/templates/04-hub-deployment.yaml
@@ -44,7 +44,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: SENTRY_ENABLED
-            value: '{{ .Values.tap.sentry.enabled }}'
+            value: '{{ (include "sentry.enabled" .) }}'
           - name: SENTRY_ENVIRONMENT
             value: '{{ .Values.tap.sentry.environment }}'
           - name: KUBESHARK_CLOUD_API_URL

--- a/helm-chart/templates/06-front-deployment.yaml
+++ b/helm-chart/templates/06-front-deployment.yaml
@@ -63,7 +63,7 @@ spec:
             - name: REACT_APP_DISSECTORS_UPDATING_ENABLED
               value: '{{ .Values.dissectorsUpdatingEnabled | ternary "true" "false" }}'
             - name: REACT_APP_SENTRY_ENABLED
-              value: '{{ .Values.tap.sentry.enabled }}'
+              value: '{{ (include "sentry.enabled" .) }}'
             - name: REACT_APP_SENTRY_ENVIRONMENT
               value: '{{ .Values.tap.sentry.environment }}'
         {{- if .Values.tap.docker.overrideTag.front }}

--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -110,6 +110,10 @@ spec:
             value: 'https://api.kubeshark.co'
           - name: PROFILING_ENABLED
             value: '{{ .Values.tap.pprof.enabled }}'
+          - name: SENTRY_ENABLED
+            value: '{{ (include "sentry.enabled" .) }}'
+          - name: SENTRY_ENVIRONMENT
+            value: '{{ .Values.tap.sentry.environment }}'
           resources:
             limits:
               cpu: {{ .Values.tap.resources.sniffer.limits.cpu }}
@@ -210,7 +214,7 @@ spec:
           - name: PROFILING_ENABLED
             value: '{{ .Values.tap.pprof.enabled }}'
           - name: SENTRY_ENABLED
-            value: '{{ .Values.tap.sentry.enabled }}'
+            value: '{{ (include "sentry.enabled" .) }}'
           - name: SENTRY_ENVIRONMENT
             value: '{{ .Values.tap.sentry.environment }}'
           resources:

--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -73,3 +73,16 @@ Create docker tag default version
 {{- end }}
 {{- $defaultVersion }}
 {{- end -}}
+
+{{/*
+Set sentry based on internet connectivity and telemetry
+*/}}
+{{- define "sentry.enabled" -}}
+  {{- $sentryEnabledVal := .Values.tap.sentry.enabled -}}
+  {{- if not .Values.internetConnectivity -}}
+    {{- $sentryEnabledVal = false -}}
+  {{- else if not .Values.tap.telemetry.enabled -}}
+    {{- $sentryEnabledVal = false -}}
+  {{- end -}}
+  {{- $sentryEnabledVal -}}
+{{- end -}}


### PR DESCRIPTION
Towards https://github.com/kubeshark/hub/issues/168

1. default

```
helm template helm-chart | grep SENTRY_ENABLED -A1
          - name: SENTRY_ENABLED
            value: 'false'
--
          - name: SENTRY_ENABLED
            value: 'false'
--
          - name: SENTRY_ENABLED
            value: 'false'
--
            - name: REACT_APP_SENTRY_ENABLED
              value: 'false'
```

2. internet connectivity overrides telemetry and sentry

```
helm template helm-chart --set internetConnectivity=false --set tap.telemetry.enabled=true --set tap.sentry.enabled=true | grep SENTRY_ENABLED -A1
          - name: SENTRY_ENABLED
            value: 'false'
--
          - name: SENTRY_ENABLED
            value: 'false'
--
          - name: SENTRY_ENABLED
            value: 'false'
--
            - name: REACT_APP_SENTRY_ENABLED
              value: 'false'
```

3. telemetry overrides sentry

```
helm template helm-chart --set internetConnectivity=true --set tap.telemetry.enabled=false --set tap.sentry.enabled=true | grep SENTRY_ENABLED -A1
          - name: SENTRY_ENABLED
            value: 'false'
--
          - name: SENTRY_ENABLED
            value: 'false'
--
          - name: SENTRY_ENABLED
            value: 'false'
--
            - name: REACT_APP_SENTRY_ENABLED
              value: 'false'
```

4. only all enabled turn sentry on

```
helm template helm-chart --set internetConnectivity=true --set tap.telemetry.enabled=true --set tap.sentry.enabled=true | grep SENTRY_ENABLED -A1
          - name: SENTRY_ENABLED
            value: 'true'
--
          - name: SENTRY_ENABLED
            value: 'true'
--
          - name: SENTRY_ENABLED
            value: 'true'
--
            - name: REACT_APP_SENTRY_ENABLED
              value: 'true'
```