### PR TITLE
feat: deamonset, deployments, pods and serviceaccount annotations and labels.

### DIFF
--- a/helm-chart/templates/01-service-account.yaml
+++ b/helm-chart/templates/01-service-account.yaml
@@ -3,10 +3,16 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    {{- include "kubeshark.labels" . | nindent 4 }}
+  {{- include "kubeshark.labels" . | nindent 4 }}
+  {{- if .Values.tap.serviceaccount.labels }}
+    {{- toYaml .Values.tap.serviceaccount.labels | nindent 4 }}
+  {{- end }}
   annotations:
   {{- if .Values.tap.annotations }}
     {{- toYaml .Values.tap.annotations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.tap.serviceaccount.annotations }}
+    {{- toYaml .Values.tap.serviceaccount.annotations | nindent 4 }}
   {{- end }}
   name: {{ include "kubeshark.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/helm-chart/templates/04-hub-deployment.yaml
+++ b/helm-chart/templates/04-hub-deployment.yaml
@@ -4,10 +4,16 @@ kind: Deployment
 metadata:
   labels:
     app.kubeshark.co/app: hub
-    {{- include "kubeshark.labels" . | nindent 4 }}
+  {{- include "kubeshark.labels" . | nindent 4 }}
+  {{- if .Values.tap.proxy.hub.deployment.labels }}
+    {{- toYaml .Values.tap.proxy.hub.deployment.labels | nindent 4 }}
+  {{- end }}
   annotations:
   {{- if .Values.tap.annotations }}
     {{- toYaml .Values.tap.annotations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.tap.proxy.hub.deployment.annotations }}
+    {{- toYaml .Values.tap.proxy.hub.deployment.annotations | nindent 4 }}
   {{- end }}
   name: {{ include "kubeshark.name" . }}-hub
   namespace: {{ .Release.Namespace }}
@@ -22,6 +28,13 @@ spec:
       labels:
         app.kubeshark.co/app: hub
         {{- include "kubeshark.labels" . | nindent 8 }}
+        {{- if .Values.tap.proxy.hub.pod.labels }}
+          {{- toYaml .Values.tap.proxy.hub.pod.labels | nindent 4 }}
+        {{- end }}
+      annotations:
+        {{- if .Values.tap.proxy.hub.pod.annotations }}
+          {{- toYaml .Values.tap.proxy.hub.pod.annotations | nindent 4 }}
+        {{- end }}
     spec:
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: {{ include "kubeshark.serviceAccountName" . }}

--- a/helm-chart/templates/05-hub-service.yaml
+++ b/helm-chart/templates/05-hub-service.yaml
@@ -4,10 +4,16 @@ kind: Service
 metadata:
   labels:
     app.kubeshark.co/app: hub
-    {{- include "kubeshark.labels" . | nindent 4 }}
+  {{- include "kubeshark.labels" . | nindent 4 }}
+  {{- if .Values.tap.proxy.hub.service.labels }}
+    {{- toYaml .Values.tap.proxy.hub.service.labels | nindent 4 }}
+  {{- end }}
   annotations:
   {{- if .Values.tap.annotations }}
     {{- toYaml .Values.tap.annotations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.tap.proxy.hub.service.annotations }}
+    {{- toYaml .Values.tap.proxy.hub.service.annotations | nindent 4 }}
   {{- end }}
   name: kubeshark-hub
   namespace: {{ .Release.Namespace }}

--- a/helm-chart/templates/06-front-deployment.yaml
+++ b/helm-chart/templates/06-front-deployment.yaml
@@ -3,10 +3,16 @@ kind: Deployment
 metadata:
   labels:
     app.kubeshark.co/app: front
-    {{- include "kubeshark.labels" . | nindent 4 }}
+  {{- include "kubeshark.labels" . | nindent 4 }}
+  {{- if .Values.tap.proxy.front.deployment.labels }}
+    {{- toYaml .Values.tap.proxy.front.deployment.labels | nindent 4 }}
+  {{- end }}
   annotations:
   {{- if .Values.tap.annotations }}
     {{- toYaml .Values.tap.annotations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.tap.proxy.front.deployment.annotations }}
+    {{- toYaml .Values.tap.proxy.front.deployment.annotations | nindent 4 }}
   {{- end }}
   name: {{ include "kubeshark.name" . }}-front
   namespace: {{ .Release.Namespace }}
@@ -20,7 +26,14 @@ spec:
     metadata:
       labels:
         app.kubeshark.co/app: front
-        {{- include "kubeshark.labels" . | nindent 8 }}
+      {{- include "kubeshark.labels" . | nindent 8 }}
+      {{- if .Values.tap.proxy.front.pod.labels }}
+        {{- toYaml .Values.tap.proxy.front.pod.labels | nindent 4 }}
+      {{- end }}
+      annotations:
+      {{- if .Values.tap.proxy.front.pod.annotations }}
+        {{- toYaml .Values.tap.proxy.front.pod.annotations | nindent 4 }}
+      {{- end }}
     spec:
       containers:
         - env:

--- a/helm-chart/templates/07-front-service.yaml
+++ b/helm-chart/templates/07-front-service.yaml
@@ -3,10 +3,16 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    {{- include "kubeshark.labels" . | nindent 4 }}
+  {{- include "kubeshark.labels" . | nindent 4 }}
+  {{- if .Values.tap.proxy.front.service.labels }}
+    {{- toYaml .Values.tap.proxy.front.service.labels | nindent 4 }}
+  {{- end }}
   annotations:
   {{- if .Values.tap.annotations }}
     {{- toYaml .Values.tap.annotations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.tap.proxy.front.service.annotations }}
+    {{- toYaml .Values.tap.proxy.front.service.annotations | nindent 4 }}
   {{- end }}
   name: kubeshark-front
   namespace: {{ .Release.Namespace }}

--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -5,10 +5,16 @@ metadata:
   labels:
     app.kubeshark.co/app: worker
     sidecar.istio.io/inject: "false"
-    {{- include "kubeshark.labels" . | nindent 4 }}
+  {{- include "kubeshark.labels" . | nindent 4 }}
+  {{- if .Values.tap.proxy.worker.daemonset.labels }}
+    {{- toYaml .Values.tap.proxy.worker.daemonset.labels | nindent 4 }}
+  {{- end }}
   annotations:
   {{- if .Values.tap.annotations }}
     {{- toYaml .Values.tap.annotations | nindent 4 }}
+  {{- end }}
+  {{- if .Values.tap.proxy.worker.daemonset.annotations }}
+    {{- toYaml .Values.tap.proxy.worker.daemonset.annotations | nindent 4 }}
   {{- end }}
   name: kubeshark-worker-daemon-set
   namespace: {{ .Release.Namespace }}
@@ -21,7 +27,14 @@ spec:
     metadata:
       labels:
         app.kubeshark.co/app: worker
-        {{- include "kubeshark.labels" . | nindent 8 }}
+      {{- include "kubeshark.labels" . | nindent 8 }}
+      {{- if .Values.tap.proxy.worker.pod.labels }}
+        {{- toYaml .Values.tap.proxy.worker.pod.labels | nindent 4 }}
+      {{- end }}
+      annotations:
+      {{- if .Values.tap.proxy.worker.pod.annotations }}
+        {{- toYaml .Values.tap.proxy.worker.pod.annotations | nindent 4 }}
+      {{- end }}
       name: kubeshark-worker-daemon-set
       namespace: kubeshark
     spec:
@@ -54,7 +67,7 @@ spec:
             - -i
             - any
             - -port
-            - '{{ .Values.tap.proxy.worker.srvPort }}'
+            - '{{ .Values.tap.proxy.worker.service.port }}'
             - -metrics-port
             - '{{ .Values.tap.metrics.port }}'
             - -packet-capture
@@ -140,14 +153,14 @@ spec:
             successThreshold: 1
             initialDelaySeconds: 5
             tcpSocket:
-              port: {{ .Values.tap.proxy.worker.srvPort }}
+              port: {{ .Values.tap.proxy.worker.service.port }}
           livenessProbe:
             periodSeconds: 1
             failureThreshold: 3
             successThreshold: 1
             initialDelaySeconds: 5
             tcpSocket:
-              port: {{ .Values.tap.proxy.worker.srvPort }}
+              port: {{ .Values.tap.proxy.worker.service.port }}
           volumeMounts:
             - mountPath: /hostproc
               name: proc
@@ -187,7 +200,7 @@ spec:
           {{- end }}
           {{- if .Values.tap.pprof.enabled }}
             - -port
-            - '{{ add .Values.tap.proxy.worker.srvPort 1 }}'
+            - '{{ add .Values.tap.proxy.worker.service.port 1 }}'
           {{- end }}
         {{- if .Values.tap.docker.overrideTag.worker }}
           image: '{{ .Values.tap.docker.registry }}/worker:{{ .Values.tap.docker.overrideTag.worker }}{{ include "kubeshark.dockerTagDebugVersion" . }}'

--- a/helm-chart/templates/12-config-map.yaml
+++ b/helm-chart/templates/12-config-map.yaml
@@ -15,7 +15,7 @@ data:
     SCRIPTING_SCRIPTS: '{}'
     INGRESS_ENABLED: '{{ .Values.tap.ingress.enabled }}'
     INGRESS_HOST: '{{ .Values.tap.ingress.host }}'
-    PROXY_FRONT_PORT: '{{ .Values.tap.proxy.front.port }}'
+    PROXY_FRONT_PORT: '{{ .Values.tap.proxy.front.service.port }}'
     AUTH_ENABLED: '{{- if and .Values.cloudLicenseEnabled (not (empty .Values.license)) -}}
                       "false"
                   {{- else -}}

--- a/helm-chart/templates/16-network-policies.yaml
+++ b/helm-chart/templates/16-network-policies.yaml
@@ -69,7 +69,7 @@ spec:
   ingress:
     - ports:
         - protocol: TCP
-          port: {{ .Values.tap.proxy.worker.srvPort }}
+          port: {{ .Values.tap.proxy.worker.service.port }}
         - protocol: TCP
           port: {{ .Values.tap.metrics.port }}
   egress:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -11,12 +11,42 @@ tap:
       front: ""
   proxy:
     worker:
-      srvPort: 30001
+      daemonset:
+        annotations: {}
+        labels: {}
+      pod:
+        annotations: {}
+        labels: {}
+      service:
+        annotations: {}
+        labels: {}
+        port: 30001
     hub:
-      srvPort: 8898
+      deployment:
+        annotations: {}
+        labels: {}
+      pod:
+        annotations: {}
+        labels: {}
+      service:
+        annotations: {}
+        labels: {}
+        port: 8898
     front:
-      port: 8899
+      deployment:
+        annotations: {}
+        labels: {}
+      pod:
+        annotations: {}
+        labels: {}
+      service:
+        annotations: {}
+        labels: {}
+        port: 8899
     host: 127.0.0.1
+  serviceaccount:
+    annotations: {}
+    labels: {}
   regex: .*
   namespaces: []
   excludedNamespaces: []


### PR DESCRIPTION
Added annotations and labels to several resources:

1) serviceaccount labels and annotations 
   for example to enable workload identity in GKE
2) service labels and annotations
  for example to add a tailscale annotation to expose a service over VPN.
3) deployment, daemonset and pod labels 
  for k8s Gatekeeper policies such as pci-dss required labels and such.