### PR TITLE
Propagate host root to the tracer

### DIFF
--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -249,6 +249,10 @@ spec:
             - mountPath: /etc/os-release
               name: os-release
               readOnly: true
+            - mountPath: /hostroot
+              mountPropagation: HostToContainer
+              name: root
+              readOnly: true
       {{- end }}
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -281,6 +285,9 @@ spec:
         - hostPath:
             path: /etc/os-release
           name: os-release
+        - hostPath:
+            path: /
+          name: root
         - name: data
 {{- if .Values.tap.persistentStorage }}
           persistentVolumeClaim:

--- a/manifests/complete.yaml
+++ b/manifests/complete.yaml
@@ -611,6 +611,10 @@ spec:
             - mountPath: /etc/os-release
               name: os-release
               readOnly: true
+            - mountPath: /hostroot
+              mountPropagation: HostToContainer
+              name: root
+              readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
       serviceAccountName: kubeshark-service-account
@@ -642,6 +646,9 @@ spec:
         - hostPath:
             path: /etc/os-release
           name: os-release
+        - hostPath:
+            path: /
+          name: root
         - name: data
           emptyDir:
             sizeLimit: 5000Mi


### PR DESCRIPTION
Host root propogation is required for https://github.com/kubeshark/worker/issues/277 and https://github.com/kubeshark/worker/issues/222