### PR TITLE
Do not enable `-unixsocket` flag of worker if no tracer is running

### DIFF
--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -59,7 +59,9 @@ spec:
             - '{{ .Values.tap.metrics.port }}'
             - -packet-capture
             - '{{ .Values.tap.packetCapture }}'
+          {{- if .Values.tap.tls }}
             - -unixsocket
+          {{- end }}
           {{- if .Values.tap.serviceMesh }}
             - -servicemesh
           {{- end }}


### PR DESCRIPTION
Towards https://github.com/kubeshark/worker/issues/284