### PR TITLE
change the tlx dissector name to tlsx

### DIFF
--- a/config/configStruct.go
+++ b/config/configStruct.go
@@ -81,7 +81,7 @@ func CreateDefaultConfig() ConfigStruct {
 				// "tcp",
 				// "udp",
 				"ws",
-				// "tls",
+				// "tlsx",
 				"ldap",
 			},
 		},


### PR DESCRIPTION
as it can be confused with https
tlsx is a dissector for TLS handshakes and not
HTTPS dissector.