### PR TITLE
from debug to logLevel

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -63,6 +63,9 @@ func InitConfig(cmd *cobra.Command) error {
 
 	Config = CreateDefaultConfig()
 	Config.Tap.Debug = DebugMode
+	if DebugMode {
+		Config.LogLevel = "debug"
+	}
 	cmdName = cmd.Name()
 	if utils.Contains([]string{
 		"clean",

--- a/config/configStruct.go
+++ b/config/configStruct.go
@@ -113,6 +113,7 @@ type ConfigStruct struct {
 	Scripting                 configStructs.ScriptingConfig `yaml:"scripting" json:"scripting"`
 	Manifests                 ManifestsConfig               `yaml:"manifests,omitempty" json:"manifests,omitempty"`
 	Timezone                  string                        `yaml:"timezone" json:"timezone"`
+	LogLevel                  string                        `yaml:"logLevel" json:"logLevel" default:"warning"`
 }
 
 func (config *ConfigStruct) ImagePullPolicy() v1.PullPolicy {

--- a/config/configStructs/tapConfig.go
+++ b/config/configStructs/tapConfig.go
@@ -230,6 +230,7 @@ type TapConfig struct {
 	Auth                         AuthConfig            `yaml:"auth" json:"auth"`
 	Ingress                      IngressConfig         `yaml:"ingress" json:"ingress"`
 	IPv6                         bool                  `yaml:"ipv6" json:"ipv6" default:"true"`
+	Debug                        bool                  `yaml:"debug" json:"debug" default:"false"`
 	Telemetry                    TelemetryConfig       `yaml:"telemetry" json:"telemetry"`
 	ResourceGuard                ResourceGuardConfig   `yaml:"resourceGuard" json:"resourceGuard"`
 	Sentry                       SentryConfig          `yaml:"sentry" json:"sentry"`

--- a/config/configStructs/tapConfig.go
+++ b/config/configStructs/tapConfig.go
@@ -230,7 +230,6 @@ type TapConfig struct {
 	Auth                         AuthConfig            `yaml:"auth" json:"auth"`
 	Ingress                      IngressConfig         `yaml:"ingress" json:"ingress"`
 	IPv6                         bool                  `yaml:"ipv6" json:"ipv6" default:"true"`
-	Debug                        bool                  `yaml:"debug" json:"debug" default:"false"`
 	Telemetry                    TelemetryConfig       `yaml:"telemetry" json:"telemetry"`
 	ResourceGuard                ResourceGuardConfig   `yaml:"resourceGuard" json:"resourceGuard"`
 	Sentry                       SentryConfig          `yaml:"sentry" json:"sentry"`

--- a/helm-chart/templates/04-hub-deployment.yaml
+++ b/helm-chart/templates/04-hub-deployment.yaml
@@ -31,9 +31,8 @@ spec:
             - ./hub
             - -port
             - "8080"
-          {{- if .Values.tap.debug }}
-            - -debug
-          {{- end }}
+            - -loglevel
+            - '{{ .Values.logLevel | default "warning" }}'
           env:
           - name: POD_NAME
             valueFrom:

--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -36,6 +36,8 @@ spec:
             - '{{ .Values.tap.metrics.port }}'
             - -packet-capture
             - '{{ .Values.tap.packetCapture }}'
+            - -loglevel
+            - '{{ .Values.logLevel | default "warning" }}'
           {{- if .Values.tap.tls }}
             - -unixsocket
           {{- end }}
@@ -54,9 +56,6 @@ spec:
             - '{{ .Values.tap.misc.resolutionStrategy }}'
             - -staletimeout
             - '{{ .Values.tap.misc.staleTimeoutSeconds }}'
-          {{- if .Values.tap.debug }}
-            - -debug
-          {{- end }}
         {{- if .Values.tap.docker.overrideImage.worker }}
           image: '{{ .Values.tap.docker.overrideImage.worker }}'
         {{- else if .Values.tap.docker.overrideTag.worker }}
@@ -156,9 +155,6 @@ spec:
           {{- if ne .Values.tap.packetCapture "ebpf" }}
             - -disable-ebpf
           {{- end }}
-          {{- if .Values.tap.debug }}
-            - -debug
-          {{- end }}
           {{- if .Values.tap.disableTlsLog }}
             - -disable-tls-log
           {{- end }}
@@ -166,6 +162,8 @@ spec:
             - -port
             - '{{ add .Values.tap.proxy.worker.srvPort 1 }}'
           {{- end }}
+            - -loglevel
+            - '{{ .Values.logLevel | default "warning" }}'
         {{- if .Values.tap.docker.overrideTag.worker }}
           image: '{{ .Values.tap.docker.registry }}/worker:{{ .Values.tap.docker.overrideTag.worker }}{{ include "kubeshark.dockerTagDebugVersion" . }}'
         {{ else }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -178,3 +178,4 @@ scripting:
   active: []
   console: true
 timezone: ""
+logLevel: warning


### PR DESCRIPTION
This PR moves from the use of `tap.debug` to `logLevel` to give more control of what appears in the logs.
To achieve the same functionality of `tap.debug=true`, the following cane be used: `logLevel=debug`
The default log level is set to `warning`