### PR TITLE
removed the loglevel flag

### DIFF
--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -162,8 +162,8 @@ spec:
             - -port
             - '{{ add .Values.tap.proxy.worker.srvPort 1 }}'
           {{- end }}
-            - -loglevel
-            - '{{ .Values.logLevel | default "warning" }}'
+            # - -loglevel
+            # - '{{ .Values.logLevel | default "warning" }}'
         {{- if .Values.tap.docker.overrideTag.worker }}
           image: '{{ .Values.tap.docker.registry }}/worker:{{ .Values.tap.docker.overrideTag.worker }}{{ include "kubeshark.dockerTagDebugVersion" . }}'
         {{ else }}


### PR DESCRIPTION
following reverting tracer version: https://github.com/kubeshark/worker/pull/478