### PR TITLE
Update worker liveness/readiness config

### DIFF
--- a/config/configStructs/tapConfig.go
+++ b/config/configStructs/tapConfig.go
@@ -117,6 +117,18 @@ type ResourcesConfig struct {
 	Tracer  ResourceRequirementsWorker `yaml:"tracer" json:"tracer"`
 }
 
+type ProbesConfig struct {
+	Hub     ProbeConfig `yaml:"hub" json:"hub"`
+	Sniffer ProbeConfig `yaml:"sniffer" json:"sniffer"`
+}
+
+type ProbeConfig struct {
+	InitialDelaySeconds int `yaml:"initialDelaySeconds" json:"initialDelaySeconds" default:"15"`
+	PeriodSeconds       int `yaml:"periodSeconds" json:"periodSeconds" default:"10"`
+	SuccessThreshold    int `yaml:"successThreshold" json:"successThreshold" default:"1"`
+	FailureThreshold    int `yaml:"failureThreshold" json:"failureThreshold" default:"3"`
+}
+
 type ScriptingPermissions struct {
 	CanSave     bool `yaml:"canSave" json:"canSave" default:"true"`
 	CanActivate bool `yaml:"canActivate" json:"canActivate" default:"true"`
@@ -228,6 +240,7 @@ type TapConfig struct {
 	StorageClass                 string                `yaml:"storageClass" json:"storageClass" default:"standard"`
 	DryRun                       bool                  `yaml:"dryRun" json:"dryRun" default:"false"`
 	Resources                    ResourcesConfig       `yaml:"resources" json:"resources"`
+	Probes                       ProbesConfig          `yaml:"probes" json:"probes"`
 	ServiceMesh                  bool                  `yaml:"serviceMesh" json:"serviceMesh" default:"true"`
 	Tls                          bool                  `yaml:"tls" json:"tls" default:"true"`
 	DisableTlsLog                bool                  `yaml:"disableTlsLog" json:"disableTlsLog" default:"true"`

--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -160,6 +160,14 @@ Example for overriding image names:
 | `tap.resources.tracer.limits.memory`      | Memory limit for tracer                       | `3Gi`                                                |
 | `tap.resources.tracer.requests.cpu`       | CPU request for tracer                        | `50m`                                                   |
 | `tap.resources.tracer.requests.memory`    | Memory request for tracer                     | `50Mi`                                                  |
+| `tap.probes.hub.initialDelaySeconds`      | Initial delay before probing the hub         | `15`                                                    |
+| `tap.probes.hub.periodSeconds`            | Period between probes for the hub             | `10`                                                    |
+| `tap.probes.hub.successThreshold`         | Number of successful probes before considering the hub healthy | `1`                                        |
+| `tap.probes.hub.failureThreshold`         | Number of failed probes before considering the hub unhealthy | `3`                                           |
+| `tap.probes.sniffer.initialDelaySeconds`  | Initial delay before probing the sniffer     | `15`                                                    |
+| `tap.probes.sniffer.periodSeconds`        | Period between probes for the sniffer         | `10`                                                    |
+| `tap.probes.sniffer.successThreshold`     | Number of successful probes before considering the sniffer healthy | `1`                                    |
+| `tap.probes.sniffer.failureThreshold`     | Number of failed probes before considering the sniffer unhealthy | `3`                                       |
 | `tap.serviceMesh`                         | Capture traffic from service meshes like Istio, Linkerd, Consul, etc.          | `true`                                                  |
 | `tap.tls`                                 | Capture the encrypted/TLS traffic from cryptography libraries like OpenSSL                         | `true`                                                  |
 | `tap.disableTlsLog`                       | Suppress logging for TLS/eBPF                 | `true`                                                 |

--- a/helm-chart/templates/04-hub-deployment.yaml
+++ b/helm-chart/templates/04-hub-deployment.yaml
@@ -65,17 +65,17 @@ spec:
             {{- end }}
         {{- end }}
           readinessProbe:
-            periodSeconds: 1
-            failureThreshold: 3
-            successThreshold: 1
-            initialDelaySeconds: 3
+            periodSeconds: {{ .Values.tap.probes.hub.periodSeconds }}
+            failureThreshold: {{ .Values.tap.probes.hub.failureThreshold }}
+            successThreshold: {{ .Values.tap.probes.hub.successThreshold }}
+            initialDelaySeconds: {{ .Values.tap.probes.hub.initialDelaySeconds }}
             tcpSocket:
               port: 8080
           livenessProbe:
-            periodSeconds: 1
-            failureThreshold: 3
-            successThreshold: 1
-            initialDelaySeconds: 3
+            periodSeconds: {{ .Values.tap.probes.hub.periodSeconds }}
+            failureThreshold: {{ .Values.tap.probes.hub.failureThreshold }}
+            successThreshold: {{ .Values.tap.probes.hub.successThreshold }}
+            initialDelaySeconds: {{ .Values.tap.probes.hub.initialDelaySeconds }}
             tcpSocket:
               port: 8080
           resources:

--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -163,17 +163,17 @@ spec:
               drop:
                 - ALL
           readinessProbe:
-            periodSeconds: 1
+            periodSeconds: 5
             failureThreshold: 3
             successThreshold: 1
-            initialDelaySeconds: 30
+            initialDelaySeconds: 15
             tcpSocket:
               port: {{ .Values.tap.proxy.worker.srvPort }}
           livenessProbe:
-            periodSeconds: 1
+            periodSeconds: 5
             failureThreshold: 3
             successThreshold: 1
-            initialDelaySeconds: 30
+            initialDelaySeconds: 15
             tcpSocket:
               port: {{ .Values.tap.proxy.worker.srvPort }}
           volumeMounts:

--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -163,14 +163,14 @@ spec:
               drop:
                 - ALL
           readinessProbe:
-            periodSeconds: 5
+            periodSeconds: 10
             failureThreshold: 3
             successThreshold: 1
             initialDelaySeconds: 15
             tcpSocket:
               port: {{ .Values.tap.proxy.worker.srvPort }}
           livenessProbe:
-            periodSeconds: 5
+            periodSeconds: 10
             failureThreshold: 3
             successThreshold: 1
             initialDelaySeconds: 15

--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -163,17 +163,17 @@ spec:
               drop:
                 - ALL
           readinessProbe:
-            periodSeconds: 10
-            failureThreshold: 3
-            successThreshold: 1
-            initialDelaySeconds: 15
+            periodSeconds: {{ .Values.tap.probes.sniffer.periodSeconds }}
+            failureThreshold: {{ .Values.tap.probes.sniffer.failureThreshold }}
+            successThreshold: {{ .Values.tap.probes.sniffer.successThreshold }}
+            initialDelaySeconds: {{ .Values.tap.probes.sniffer.initialDelaySeconds }}
             tcpSocket:
               port: {{ .Values.tap.proxy.worker.srvPort }}
           livenessProbe:
-            periodSeconds: 10
-            failureThreshold: 3
-            successThreshold: 1
-            initialDelaySeconds: 15
+            periodSeconds: {{ .Values.tap.probes.sniffer.periodSeconds }}
+            failureThreshold: {{ .Values.tap.probes.sniffer.failureThreshold }}
+            successThreshold: {{ .Values.tap.probes.sniffer.successThreshold }}
+            initialDelaySeconds: {{ .Values.tap.probes.sniffer.initialDelaySeconds }}
             tcpSocket:
               port: {{ .Values.tap.proxy.worker.srvPort }}
           volumeMounts:

--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -166,14 +166,14 @@ spec:
             periodSeconds: 1
             failureThreshold: 3
             successThreshold: 1
-            initialDelaySeconds: 5
+            initialDelaySeconds: 30
             tcpSocket:
               port: {{ .Values.tap.proxy.worker.srvPort }}
           livenessProbe:
             periodSeconds: 1
             failureThreshold: 3
             successThreshold: 1
-            initialDelaySeconds: 5
+            initialDelaySeconds: 30
             tcpSocket:
               port: {{ .Values.tap.proxy.worker.srvPort }}
           volumeMounts:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -59,6 +59,17 @@ tap:
       requests:
         cpu: 50m
         memory: 50Mi
+  probes:
+    hub:
+      initialDelaySeconds: 15
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 3
+    sniffer:
+      initialDelaySeconds: 15
+      periodSeconds: 10
+      successThreshold: 1
+      failureThreshold: 3
   serviceMesh: true
   tls: true
   disableTlsLog: true


### PR DESCRIPTION
Current 5s is not enough for large envs.
It also probably makes sense to make it template, but then whole liveness/readiness would need to be templated.
So for now:
- change init to 15s
- change period to 10s
So we have to think about making templates looking more community helm charts templates