### PR TITLE
Add dest arg to pcap dump struct

### DIFF
--- a/config/configStructs/tapConfig.go
+++ b/config/configStructs/tapConfig.go
@@ -222,6 +222,7 @@ type PcapDumpConfig struct {
 	PcapMaxSize      string `yaml:"maxSize" json:"maxSize" default:"500MB"`
 	PcapSrcDir       string `yaml:"pcapSrcDir" json:"pcapSrcDir" default:"pcapdump"`
 	PcapTime         string `yaml:"time" json:"time" default:"time"`
+	PcapDest         string `yaml:"dest" json:"dest" default:""`
 }
 
 type TapConfig struct {


### PR DESCRIPTION
Add dest arg to pcap dump struct in order to fix the warning received when running the command with dest arg.