### PR TITLE
Fix error on getting namespaces for pcap target files

### DIFF
--- a/cmd/pcapDumpRunner.go
+++ b/cmd/pcapDumpRunner.go
@@ -269,6 +269,8 @@ func copyPcapFiles(clientset *kubernetes.Clientset, config *rest.Config, destDir
 
 	targetNamespaces := kubernetesProvider.GetNamespaces()
 
+	log.Warn().Msgf("targetNamespaces %v", targetNamespaces)
+
 	// List worker pods
 	workerPods, err := listWorkerPods(context.Background(), clientset, targetNamespaces)
 	if err != nil {
@@ -279,12 +281,15 @@ func copyPcapFiles(clientset *kubernetes.Clientset, config *rest.Config, destDir
 
 	// Iterate over each pod to get the PCAP directory from config and copy files
 	for _, pod := range workerPods {
+		log.Warn().Msgf("getting files from pod %v", pod.Name)
 		// Get the list of NamespaceFiles (files per namespace) and their source directories
 		namespaceFiles, err := listFilesInPodDir(context.Background(), clientset, config, pod.Name, targetNamespaces, SELF_RESOURCES_PREFIX+SUFFIX_CONFIG_MAP, "PCAP_SRC_DIR", cutoffTime)
 		if err != nil {
 			log.Error().Err(err).Msgf("Error listing files in pod %s", pod.Name)
 			continue
 		}
+
+		log.Warn().Msgf("got files from pod %v files %v", pod.Name, namespaceFiles)
 
 		// Copy each file from the pod to the local destination for each namespace
 		for _, nsFiles := range namespaceFiles {

--- a/cmd/pcapDumpRunner.go
+++ b/cmd/pcapDumpRunner.go
@@ -280,13 +280,16 @@ func mergePCAPs(outputFile string, inputFiles []string) error {
 
 // copyPcapFiles function for copying the PCAP files from the worker pods
 func copyPcapFiles(clientset *kubernetes.Clientset, config *rest.Config, destDir string, cutoffTime *time.Time) error {
-	kubernetesProvider, err := getKubernetesProviderForCli(false, false)
+	namespaceList, err := clientset.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		log.Error().Err(err).Send()
+		log.Error().Err(err).Msg("Error listing namespaces")
 		return err
 	}
 
-	targetNamespaces := kubernetesProvider.GetNamespaces()
+	var targetNamespaces []string
+	for _, ns := range namespaceList.Items {
+		targetNamespaces = append(targetNamespaces, ns.Name)
+	}
 
 	log.Warn().Msgf("targetNamespaces %v", targetNamespaces)
 

--- a/config/configStructs/tapConfig.go
+++ b/config/configStructs/tapConfig.go
@@ -222,6 +222,7 @@ type PcapDumpConfig struct {
 	PcapMaxSize      string `yaml:"maxSize" json:"maxSize" default:"500MB"`
 	PcapSrcDir       string `yaml:"pcapSrcDir" json:"pcapSrcDir" default:"pcapdump"`
 	PcapTime         string `yaml:"time" json:"time" default:"time"`
+	PcapDest         string `yaml:"dest" json:"dest" default:""`
 }
 
 type TapConfig struct {


### PR DESCRIPTION
Look for workers in all the available namespaces in order to make sure that none of them are skipped when the backend settings are changed to target or exclude some of the namespaces.
Remove gopacket from the merging operation in order to increase the performance.