### PR TITLE
added `-disable-tracer` option

### DIFF
--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -73,6 +73,8 @@ spec:
             - '{{ .Values.logLevel | default "warning" }}'
           {{- if .Values.tap.tls }}
             - -unixsocket
+          {{- else }}
+            - -disable-tracer
           {{- end }}
           {{- if .Values.tap.serviceMesh }}
             - -servicemesh


### PR DESCRIPTION
to the worker daemon set, when `tap.tls=false` is set.