### PR TITLE
Remove init container; remove -disable-ebpf option

### DIFF
--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -31,7 +31,12 @@ spec:
           - /bin/sh
           - -c
           - mkdir -p /sys/fs/bpf && mount | grep -q '/sys/fs/bpf' || mount -t bpf bpf /sys/fs/bpf
-          image: busybox
+          {{- if .Values.tap.docker.overrideTag.worker }}
+          image: '{{ .Values.tap.docker.registry }}/worker:{{ .Values.tap.docker.overrideTag.worker }}{{ include "kubeshark.dockerTagDebugVersion" . }}'
+        {{ else }}
+          image: '{{ .Values.tap.docker.registry }}/worker:{{ not (eq .Values.tap.docker.tag "") | ternary .Values.tap.docker.tag (include "kubeshark.defaultVersion" .) }}{{ include "kubeshark.dockerTagDebugVersion" . }}'
+        {{- end }}
+          imagePullPolicy: {{ .Values.tap.docker.imagePullPolicy }}
           name: mount-bpf
           securityContext:
             privileged: true

--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -25,39 +25,21 @@ spec:
       name: kubeshark-worker-daemon-set
       namespace: kubeshark
     spec:
+      {{- if .Values.tap.mountBpf }}
       initContainers:
         - command:
           - /bin/sh
           - -c
           - mkdir -p /sys/fs/bpf && mount | grep -q '/sys/fs/bpf' || mount -t bpf bpf /sys/fs/bpf
-        {{- if .Values.tap.docker.overrideTag.worker }}
-          image: '{{ .Values.tap.docker.registry }}/worker:{{ .Values.tap.docker.overrideTag.worker }}{{ include "kubeshark.dockerTagDebugVersion" . }}'
-        {{ else }}
-          image: '{{ .Values.tap.docker.registry }}/worker:{{ not (eq .Values.tap.docker.tag "") | ternary .Values.tap.docker.tag (include "kubeshark.defaultVersion" .) }}{{ include "kubeshark.dockerTagDebugVersion" . }}'
-        {{- end }}
-          imagePullPolicy: {{ .Values.tap.docker.imagePullPolicy }}
-          name: check-bpf
+          image: busybox
+          name: mount-bpf
           securityContext:
             privileged: true
           volumeMounts:
           - mountPath: /sys
             name: sys
             mountPropagation: Bidirectional
-        - command:
-          - ./tracer
-          - -init-bpf
-        {{- if .Values.tap.docker.overrideTag.worker }}
-          image: '{{ .Values.tap.docker.registry }}/worker:{{ .Values.tap.docker.overrideTag.worker }}{{ include "kubeshark.dockerTagDebugVersion" . }}'
-        {{ else }}
-          image: '{{ .Values.tap.docker.registry }}/worker:{{ not (eq .Values.tap.docker.tag "") | ternary .Values.tap.docker.tag (include "kubeshark.defaultVersion" .) }}{{ include "kubeshark.dockerTagDebugVersion" . }}'
-        {{- end }}
-          imagePullPolicy: {{ .Values.tap.docker.imagePullPolicy }}
-          name: init-bpf
-          securityContext:
-            privileged: true
-          volumeMounts:
-          - mountPath: /sys
-            name: sys
+      {{- end }}
       containers:
         - command:
             - ./worker
@@ -71,9 +53,7 @@ spec:
             - '{{ .Values.tap.packetCapture }}'
             - -loglevel
             - '{{ .Values.logLevel | default "warning" }}'
-          {{- if .Values.tap.tls }}
-            - -unixsocket
-          {{- else }}
+          {{- if not .Values.tap.tls }}
             - -disable-tracer
           {{- end }}
           {{- if .Values.tap.serviceMesh }}
@@ -81,9 +61,6 @@ spec:
           {{- end }}
             - -procfs
             - /hostproc
-          {{- if eq .Values.tap.packetCapture "af_packet" }}
-            - -disable-ebpf
-          {{- end }}
           {{- if .Values.tap.resourceGuard.enabled }}
             - -enable-resource-guard
           {{- end }}
@@ -185,6 +162,7 @@ spec:
             - mountPath: /sys
               name: sys
               readOnly: true
+              mountPropagation: HostToContainer
             - mountPath: /app/data
               name: data
       {{- if .Values.tap.tls }}
@@ -192,9 +170,6 @@ spec:
             - ./tracer
             - -procfs
             - /hostproc
-          {{- if eq .Values.tap.packetCapture "af_packet" }}
-            - -disable-ebpf
-          {{- end }}
           {{- if .Values.tap.disableTlsLog }}
             - -disable-tls-log
           {{- end }}
@@ -202,8 +177,8 @@ spec:
             - -port
             - '{{ add .Values.tap.proxy.worker.srvPort 1 }}'
           {{- end }}
-            # - -loglevel
-            # - '{{ .Values.logLevel | default "warning" }}'
+            - -loglevel
+            - '{{ .Values.logLevel | default "warning" }}'
         {{- if .Values.tap.docker.overrideTag.worker }}
           image: '{{ .Values.tap.docker.registry }}/worker:{{ .Values.tap.docker.overrideTag.worker }}{{ include "kubeshark.dockerTagDebugVersion" . }}'
         {{ else }}
@@ -259,6 +234,7 @@ spec:
             - mountPath: /sys
               name: sys
               readOnly: true
+              mountPropagation: HostToContainer
             - mountPath: /app/data
               name: data
             - mountPath: /etc/os-release

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -76,6 +76,7 @@ tap:
       failureThreshold: 3
   serviceMesh: true
   tls: true
+  mountBpf: true
   disableTlsLog: true
   packetCapture: best
   ignoreTainted: false


### PR DESCRIPTION
Changes:
* add `tap.mountBpf` parameter to activate first init container
* removed second init container
* removed deprecated `-unixsocket` worker argument
* removed deprecated `-disable-ebpf` worker and tracer arguments

resolves https://github.com/kubeshark/worker/issues/540 
resolves https://github.com/kubeshark/devops/issues/34
see also https://github.com/kubeshark/worker/pull/544
