### PR TITLE
Worker component security context refactoring 

### DIFF
--- a/config/configStruct.go
+++ b/config/configStruct.go
@@ -51,31 +51,35 @@ func CreateDefaultConfig() ConfigStruct {
 					},
 				},
 			},
-			Capabilities: configStructs.CapabilitiesConfig{
-				NetworkCapture: []string{
-					// NET_RAW is required to listen the network traffic
-					"NET_RAW",
-					// NET_ADMIN is required to listen the network traffic
-					"NET_ADMIN",
-				},
-				ServiceMeshCapture: []string{
-					// SYS_ADMIN is required to read /proc/PID/net/ns + to install eBPF programs (kernel < 5.8)
-					"SYS_ADMIN",
-					// SYS_PTRACE is required to set netns to other process + to open libssl.so of other process
-					"SYS_PTRACE",
-					// DAC_OVERRIDE is required to read /proc/PID/environ
-					"DAC_OVERRIDE",
-				},
-				EBPFCapture: []string{
-					// SYS_ADMIN is required to read /proc/PID/net/ns + to install eBPF programs (kernel < 5.8)
-					"SYS_ADMIN",
-					// SYS_PTRACE is required to set netns to other process + to open libssl.so of other process
-					"SYS_PTRACE",
-					// SYS_RESOURCE is required to change rlimits for eBPF
-					"SYS_RESOURCE",
-					// IPC_LOCK is required for ebpf perf buffers allocations after some amount of size buffer size:
-					// https://github.com/kubeshark/tracer/blob/13e24725ba8b98216dd0e553262e6d9c56dce5fa/main.go#L82)
-					"IPC_LOCK",
+			SecurityContext: configStructs.SecurityContextConfig{
+				Privileged: true,
+				// Capabilities used only when running in unprivileged mode
+				Capabilities: configStructs.CapabilitiesConfig{
+					NetworkCapture: []string{
+						// NET_RAW is required to listen the network traffic
+						"NET_RAW",
+						// NET_ADMIN is required to listen the network traffic
+						"NET_ADMIN",
+					},
+					ServiceMeshCapture: []string{
+						// SYS_ADMIN is required to read /proc/PID/net/ns + to install eBPF programs (kernel < 5.8)
+						"SYS_ADMIN",
+						// SYS_PTRACE is required to set netns to other process + to open libssl.so of other process
+						"SYS_PTRACE",
+						// DAC_OVERRIDE is required to read /proc/PID/environ
+						"DAC_OVERRIDE",
+					},
+					EBPFCapture: []string{
+						// SYS_ADMIN is required to read /proc/PID/net/ns + to install eBPF programs (kernel < 5.8)
+						"SYS_ADMIN",
+						// SYS_PTRACE is required to set netns to other process + to open libssl.so of other process
+						"SYS_PTRACE",
+						// SYS_RESOURCE is required to change rlimits for eBPF
+						"SYS_RESOURCE",
+						// IPC_LOCK is required for ebpf perf buffers allocations after some amount of size buffer size:
+						// https://github.com/kubeshark/tracer/blob/13e24725ba8b98216dd0e553262e6d9c56dce5fa/main.go#L82)
+						"IPC_LOCK",
+					},
 				},
 			},
 			Auth: configStructs.AuthConfig{

--- a/config/configStructs/tapConfig.go
+++ b/config/configStructs/tapConfig.go
@@ -251,6 +251,25 @@ type PortMapping struct {
 	DIAMETER []uint16 `yaml:"diameter" json:"diameter"`
 }
 
+type SecurityContextConfig struct {
+	Privileged      bool                  `yaml:"privileged" json:"privileged" default:"true"`
+	AppArmorProfile AppArmorProfileConfig `yaml:"appArmorProfile" json:"appArmorProfile"`
+	SeLinuxOptions  SeLinuxOptionsConfig  `yaml:"seLinuxOptions" json:"seLinuxOptions"`
+	Capabilities    CapabilitiesConfig    `yaml:"capabilities" json:"capabilities"`
+}
+
+type AppArmorProfileConfig struct {
+	Type             string `yaml:"type" json:"type"`
+	LocalhostProfile string `yaml:"localhostProfile" json:"localhostProfile"`
+}
+
+type SeLinuxOptionsConfig struct {
+	Level string `yaml:"level" json:"level"`
+	Role  string `yaml:"role" json:"role"`
+	Type  string `yaml:"type" json:"type"`
+	User  string `yaml:"user" json:"user"`
+}
+
 type TapConfig struct {
 	Docker                       DockerConfig            `yaml:"docker" json:"docker"`
 	Proxy                        ProxyConfig             `yaml:"proxy" json:"proxy"`
@@ -286,7 +305,6 @@ type TapConfig struct {
 	Sentry                       SentryConfig            `yaml:"sentry" json:"sentry"`
 	DefaultFilter                string                  `yaml:"defaultFilter" json:"defaultFilter" default:"!dns and !error"`
 	LiveConfigMapChangesDisabled bool                    `yaml:"liveConfigMapChangesDisabled" json:"liveConfigMapChangesDisabled" default:"false"`
-	Capabilities                 CapabilitiesConfig      `yaml:"capabilities" json:"capabilities"`
 	GlobalFilter                 string                  `yaml:"globalFilter" json:"globalFilter" default:""`
 	EnabledDissectors            []string                `yaml:"enabledDissectors" json:"enabledDissectors"`
 	PortMapping                  PortMapping             `yaml:"portMapping" json:"portMapping"`
@@ -294,6 +312,7 @@ type TapConfig struct {
 	Metrics                      MetricsConfig           `yaml:"metrics" json:"metrics"`
 	Pprof                        PprofConfig             `yaml:"pprof" json:"pprof"`
 	Misc                         MiscConfig              `yaml:"misc" json:"misc"`
+	SecurityContext              SecurityContextConfig   `yaml:"securityContext" json:"securityContext"`
 }
 
 func (config *TapConfig) PodRegex() *regexp.Regexp {

--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -147,23 +147,52 @@ spec:
               memory: {{ .Values.tap.resources.sniffer.requests.memory }}
               {{ end }}
           securityContext:
+            privileged: {{ .Values.tap.securityContext.privileged }}
+            {{- if not .Values.tap.securityContext.privileged }}
+            {{- $aaProfile := .Values.tap.securityContext.appArmorProfile }}
+            {{- $selinuxOpts := .Values.tap.securityContext.seLinuxOptions }}
+            {{- if or (ne $aaProfile.type "") (ne $aaProfile.localhostProfile "") }}
+            appArmorProfile:
+              {{- if ne $aaProfile.type "" }}
+              type: {{ $aaProfile.type }}
+              {{- end }}
+              {{- if ne $aaProfile.localhostProfile "" }}
+              localhostProfile: {{ $aaProfile.localhostProfile }}
+              {{- end }}
+            {{- end }}
+            {{- if or (ne $selinuxOpts.level "") (ne $selinuxOpts.role "") (ne $selinuxOpts.type "") (ne $selinuxOpts.user "") }}
+            seLinuxOptions:
+              {{- if ne $selinuxOpts.level "" }}
+              level: {{ $selinuxOpts.level }}
+              {{- end }}
+              {{- if ne $selinuxOpts.role "" }}
+              role: {{ $selinuxOpts.role }}
+              {{- end }}
+              {{- if ne $selinuxOpts.type "" }}
+              type: {{ $selinuxOpts.type }}
+              {{- end }}
+              {{- if ne $selinuxOpts.user "" }}
+              user: {{ $selinuxOpts.user }}
+              {{- end }}
+            {{- end }}
             capabilities:
               add:
-                {{- range .Values.tap.capabilities.networkCapture }}
+                {{- range .Values.tap.securityContext.capabilities.networkCapture }}
                 {{ print "- " . }}
                 {{- end }}
                 {{- if .Values.tap.serviceMesh }}
-                {{- range .Values.tap.capabilities.serviceMeshCapture }}
+                {{- range .Values.tap.securityContext.capabilities.serviceMeshCapture }}
                 {{ print "- " . }}
                 {{- end }}
                 {{- end }}
-                {{- if .Values.tap.capabilities.ebpfCapture }}
-                {{- range .Values.tap.capabilities.ebpfCapture }}
+                {{- if .Values.tap.securityContext.capabilities.ebpfCapture }}
+                {{- range .Values.tap.securityContext.capabilities.ebpfCapture }}
                 {{ print "- " . }}
                 {{- end }}
                 {{- end }}
               drop:
                 - ALL
+            {{- end }}
           readinessProbe:
             periodSeconds: {{ .Values.tap.probes.sniffer.periodSeconds }}
             failureThreshold: {{ .Values.tap.probes.sniffer.failureThreshold }}
@@ -242,16 +271,45 @@ spec:
               memory: {{ .Values.tap.resources.tracer.requests.memory }}
               {{ end }}
           securityContext:
+            privileged: {{ .Values.tap.securityContext.privileged }}
+            {{- if not .Values.tap.securityContext.privileged }}
+            {{- $aaProfile := .Values.tap.securityContext.appArmorProfile }}
+            {{- $selinuxOpts := .Values.tap.securityContext.seLinuxOptions }}
+            {{- if or (ne $aaProfile.type "") (ne $aaProfile.localhostProfile "") }}
+            appArmorProfile:
+              {{- if ne $aaProfile.type "" }}
+              type: {{ $aaProfile.type }}
+              {{- end }}
+              {{- if ne $aaProfile.localhostProfile "" }}
+              localhostProfile: {{ $aaProfile.localhostProfile }}
+              {{- end }}
+            {{- end }}
+            {{- if or (ne $selinuxOpts.level "") (ne $selinuxOpts.role "") (ne $selinuxOpts.type "") (ne $selinuxOpts.user "") }}
+            seLinuxOptions:
+              {{- if ne $selinuxOpts.level "" }}
+              level: {{ $selinuxOpts.level }}
+              {{- end }}
+              {{- if ne $selinuxOpts.role "" }}
+              role: {{ $selinuxOpts.role }}
+              {{- end }}
+              {{- if ne $selinuxOpts.type "" }}
+              type: {{ $selinuxOpts.type }}
+              {{- end }}
+              {{- if ne $selinuxOpts.user "" }}
+              user: {{ $selinuxOpts.user }}
+              {{- end }}
+            {{- end }}
             capabilities:
               add:
-                {{- range .Values.tap.capabilities.ebpfCapture }}
+                {{- range .Values.tap.securityContext.capabilities.ebpfCapture }}
                 {{ print "- " . }}
                 {{- end }}
-                {{- range .Values.tap.capabilities.networkCapture }}
+                {{- range .Values.tap.securityContext.capabilities.networkCapture }}
                 {{ print "- " . }}
                 {{- end }}
               drop:
                 - ALL
+            {{- end }}
           volumeMounts:
             - mountPath: /hostproc
               name: proc

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -137,19 +137,6 @@ tap:
     environment: production
   defaultFilter: "!dns and !error"
   liveConfigMapChangesDisabled: false
-  capabilities:
-    networkCapture:
-    - NET_RAW
-    - NET_ADMIN
-    serviceMeshCapture:
-    - SYS_ADMIN
-    - SYS_PTRACE
-    - DAC_OVERRIDE
-    ebpfCapture:
-    - SYS_ADMIN
-    - SYS_PTRACE
-    - SYS_RESOURCE
-    - IPC_LOCK
   globalFilter: ""
   enabledDissectors:
   - amqp
@@ -199,6 +186,29 @@ tap:
     duplicateTimeframe: 200ms
     detectDuplicates: false
     staleTimeoutSeconds: 30
+  securityContext:
+    privileged: true
+    appArmorProfile:
+      type: ""
+      localhostProfile: ""
+    seLinuxOptions:
+      level: ""
+      role: ""
+      type: ""
+      user: ""
+    capabilities:
+      networkCapture:
+      - NET_RAW
+      - NET_ADMIN
+      serviceMeshCapture:
+      - SYS_ADMIN
+      - SYS_PTRACE
+      - DAC_OVERRIDE
+      ebpfCapture:
+      - SYS_ADMIN
+      - SYS_PTRACE
+      - SYS_RESOURCE
+      - IPC_LOCK
 logs:
   file: ""
   grep: ""
@@ -208,6 +218,8 @@ pcapdump:
   maxTime: 1h
   maxSize: 500MB
   time: time
+  debug: false
+  dest: ""
 kube:
   configPath: ""
   context: ""


### PR DESCRIPTION
Towards https://github.com/kubeshark/worker/issues/547

Added new `tap.securityContext` configuration block.

Now by default we set `tap.securityContext.privileged=true`.
This generates template like 

```
          securityContext:
            privileged: true
```

If user wants to run unprivileged container, option can be set to false. Then proper capabilities are added automatically.
Also optionally use can configure appArmorProfile or seLinuxOptions.

Examples

### disable privileged, enable AppArmor profile

```
helm template helm-chart --set tap.securityContext.privileged=false --set tap.securityContext.appArmorProfile.type=Localhost
```

```
          securityContext:
            privileged: false
            appArmorProfile:
              type: Localhost
            capabilities:
              add:
                - NET_RAW
                - NET_ADMIN
                - SYS_ADMIN
                - SYS_PTRACE
                - DAC_OVERRIDE
                - SYS_ADMIN
                - SYS_PTRACE
                - SYS_RESOURCE
                - IPC_LOCK
              drop:
                - ALL
 ```

### disable privileged, enable AppArmor profile + some selinux

```
helm template helm-chart --set tap.securityContext.privileged=false --set tap.securityContext.appArmorProfile.type=Localhost --set tap.securityContext.seLinuxOptions.type=sometype
```

```
          securityContext:
            privileged: false
            appArmorProfile:
              type: Localhost
            seLinuxOptions:
              type: sometype
            capabilities:
              add:
                - NET_RAW
                - NET_ADMIN
                - SYS_ADMIN
                - SYS_PTRACE
                - DAC_OVERRIDE
                - SYS_ADMIN
                - SYS_PTRACE
                - SYS_RESOURCE
                - IPC_LOCK
              drop:
                - ALL
```