### PR TITLE
Sentry Enabled By Default

### DIFF
--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -200,7 +200,7 @@ Example for overriding image names:
 | `tap.debug`                               | Enable debug mode                             | `false`                                                 |
 | `tap.telemetry.enabled`                   | Enable anonymous usage statistics collection           | `true`                                                  |
 | `tap.resourceGuard.enabled`               | Enable resource guard worker process, which watches RAM/disk usage and enables/disables traffic capture based on available resources | `false` |
-| `tap.sentry.enabled`                      | Enable sending of error logs to Sentry          | `false`                                                  |
+| `tap.sentry.enabled`                      | Enable sending of error logs to Sentry          | `true` (only for qualified users)                                                  |
 | `tap.sentry.environment`                      | Sentry environment to label error logs with      | `production`                                                  |
 | `tap.defaultFilter`                       | Sets the default dashboard KFL filter (e.g. `http`). By default, this value is set to filter out noisy protocols such as DNS, UDP, ICMP and TCP. The user can easily change this, **temporarily**, in the Dashboard. For a permanent change, you should change this value in the `values.yaml` or `config.yaml` file.        | `"!dns and !error"`                                    |
 | `tap.liveConfigMapChangesDisabled`        | If set to `true`, all user functionality (scripting, targeting settings, global & default KFL modification, traffic recording, traffic capturing on/off, protocol dissectors) involving dynamic ConfigMap changes from UI will be disabled     | `false`      |

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -138,7 +138,7 @@ tap:
   resourceGuard:
     enabled: false
   sentry:
-    enabled: false
+    enabled: true
     environment: production
   defaultFilter: "!dns and !error"
   liveConfigMapChangesDisabled: false


### PR DESCRIPTION
Sentry is enabled by default for qualified users, and depending on the license tier.
Having Sentry enabled sends rich telemetry enabling better support.