### PR TITLE
Add override for pvc volumeMode in helm chart

### DIFF
--- a/helm-chart/README.md
+++ b/helm-chart/README.md
@@ -144,6 +144,7 @@ Example for overriding image names:
 | `tap.release.namespace`                   | Helm release namespace                        | `default`                                               |
 | `tap.persistentStorage`                   | Use `persistentVolumeClaim` instead of `emptyDir` | `false`                                             |
 | `tap.persistentStorageStatic`             | Use static persistent volume provisioning (explicitly defined `PersistentVolume` ) | `false`            |
+| `tap.persistentStoragePvcVolumeMode`      | Set the pvc volume mode (Filesystem\|Block) | `Filesystem`                                               |
 | `tap.efsFileSytemIdAndPath`               | [EFS file system ID and, optionally, subpath and/or access point](https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/examples/kubernetes/access_points/README.md) `<FileSystemId>:<Path>:<AccessPointId>`  | ""                             |
 | `tap.storageLimit`                        | Limit of either the `emptyDir` or `persistentVolumeClaim` | `500Mi`                                     |
 | `tap.storageClass`                        | Storage class of the `PersistentVolumeClaim`          | `standard`                                      |

--- a/helm-chart/templates/08-persistent-volume-claim.yaml
+++ b/helm-chart/templates/08-persistent-volume-claim.yaml
@@ -33,6 +33,7 @@ metadata:
   name: kubeshark-persistent-volume-claim
   namespace: {{ .Release.Namespace }}
 spec:
+  volumeMode: {{ .Values.tap.persistentStoragePvcVolumeMode }}
   accessModes:
     - ReadWriteMany
   resources:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -33,6 +33,7 @@ tap:
     namespace: default
   persistentStorage: false
   persistentStorageStatic: false
+  persistentStoragePvcVolumeMode: Filesystem
   efsFileSytemIdAndPath: ""
   storageLimit: 5000Mi
   storageClass: standard


### PR DESCRIPTION
Required to use the azure-csi-premium for RWX PVC as its a block device.
docs: https://github.com/kubernetes-sigs/azuredisk-csi-driver/tree/master/deploy/example/sharedisk