### PR TITLE
Enable bpf override for secondary af_packet

### DIFF
--- a/helm-chart/templates/06-front-deployment.yaml
+++ b/helm-chart/templates/06-front-deployment.yaml
@@ -61,7 +61,7 @@ spec:
             - name: REACT_APP_PRESET_FILTERS_CHANGING_ENABLED
               value: '{{ .Values.tap.liveConfigMapChangesDisabled | ternary "false" "true" }}'
             - name: REACT_APP_BPF_OVERRIDE_DISABLED
-              value: '{{ eq .Values.tap.packetCapture "af_packet" | ternary "false" "true" }}'
+              value: '{{ has .Values.tap.packetCapture (list "af_packet" "ebpf" "best") | ternary "false" "true" }}'
             - name: REACT_APP_RECORDING_DISABLED
               value: '{{ .Values.tap.liveConfigMapChangesDisabled }}'
             - name: REACT_APP_STOP_TRAFFIC_CAPTURING_DISABLED


### PR DESCRIPTION
Towards: https://github.com/kubeshark/worker/issues/655