### PR TITLE
Add `--config-path` flag to root command

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"path"
 
 	"github.com/creasty/defaults"
 	"github.com/kubeshark/kubeshark/config"
@@ -52,5 +51,5 @@ func init() {
 		log.Debug().Err(err).Send()
 	}
 
-	configCmd.Flags().BoolP(configStructs.RegenerateConfigName, "r", defaultConfig.Config.Regenerate, fmt.Sprintf("Regenerate the config file with default values to path %s", path.Join(misc.GetDotFolderPath(), "config.yaml")))
+	configCmd.Flags().BoolP(configStructs.RegenerateConfigName, "r", defaultConfig.Config.Regenerate, fmt.Sprintf("Regenerate the config file with default values to path %s", config.GetConfigFilePath(nil)))
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,6 +33,7 @@ func init() {
 
 	rootCmd.PersistentFlags().StringSlice(config.SetCommandName, []string{}, fmt.Sprintf("Override values using --%s", config.SetCommandName))
 	rootCmd.PersistentFlags().BoolP(config.DebugFlag, "d", false, "Enable debug mode")
+	rootCmd.PersistentFlags().String(config.ConfigPathFlag, "", fmt.Sprintf("Set the config path, default: %s", config.GetConfigFilePath(nil)))
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/config/config.go
+++ b/config/config.go
@@ -147,7 +147,12 @@ func GetConfigFilePath(cmd *cobra.Command) string {
 		configPathOverride, err := cmd.Flags().GetString(ConfigPathFlag)
 		if err == nil {
 			if configPathOverride != "" {
-				return filepath.Join(cwd, configPathOverride)
+				resolvedConfigPath, err := filepath.Abs(configPathOverride)
+				if err != nil {
+					log.Error().Err(err).Msg("--config-path flag path cannot be resolved")
+				} else {
+					return resolvedConfigPath
+				}
 			}
 		} else {
 			log.Error().Err(err).Msg("--config-path flag parser error")

--- a/config/config.go
+++ b/config/config.go
@@ -28,6 +28,7 @@ const (
 	FieldNameTag   = "yaml"
 	ReadonlyTag    = "readonly"
 	DebugFlag      = "debug"
+	ConfigPathFlag = "config-path"
 )
 
 var (
@@ -82,7 +83,7 @@ func InitConfig(cmd *cobra.Command) error {
 		return err
 	}
 
-	ConfigFilePath = path.Join(misc.GetDotFolderPath(), "config.yaml")
+	ConfigFilePath = GetConfigFilePath(cmd)
 	if err := loadConfigFile(&Config, utils.Contains([]string{
 		"manifests",
 		"license",
@@ -134,21 +135,39 @@ func WriteConfig(config *ConfigStruct) error {
 	return nil
 }
 
-func loadConfigFile(config *ConfigStruct, silent bool) error {
+func GetConfigFilePath(cmd *cobra.Command) string {
+	defaultConfigPath := path.Join(misc.GetDotFolderPath(), "config.yaml")
+
 	cwd, err := os.Getwd()
 	if err != nil {
-		return err
+		return defaultConfigPath
+	}
+
+	if cmd != nil {
+		configPathOverride, err := cmd.Flags().GetString(ConfigPathFlag)
+		if err == nil {
+			if configPathOverride != "" {
+				return filepath.Join(cwd, configPathOverride)
+			}
+		} else {
+			log.Error().Err(err).Msg("--config-path flag parser error")
+		}
 	}
 
 	cwdConfig := filepath.Join(cwd, fmt.Sprintf("%s.yaml", misc.Program))
 	reader, err := os.Open(cwdConfig)
 	if err != nil {
-		reader, err = os.Open(ConfigFilePath)
-		if err != nil {
-			return err
-		}
+		return defaultConfigPath
 	} else {
-		ConfigFilePath = cwdConfig
+		reader.Close()
+		return cwdConfig
+	}
+}
+
+func loadConfigFile(config *ConfigStruct, silent bool) error {
+	reader, err := os.Open(ConfigFilePath)
+	if err != nil {
+		return err
 	}
 	defer reader.Close()
 
@@ -176,9 +195,14 @@ func initFlag(f *pflag.Flag) {
 
 	flagPath = append(flagPath, strings.Split(f.Name, "-")...)
 
+	flagPathJoined := strings.Join(flagPath, ".")
+	if strings.HasSuffix(flagPathJoined, ".config.path") {
+		return
+	}
+
 	sliceValue, isSliceValue := f.Value.(pflag.SliceValue)
 	if !isSliceValue {
-		if err := mergeFlagValue(configElemValue, flagPath, strings.Join(flagPath, "."), f.Value.String()); err != nil {
+		if err := mergeFlagValue(configElemValue, flagPath, flagPathJoined, f.Value.String()); err != nil {
 			log.Warn().Err(err).Send()
 		}
 		return
@@ -191,7 +215,7 @@ func initFlag(f *pflag.Flag) {
 		return
 	}
 
-	if err := mergeFlagValues(configElemValue, flagPath, strings.Join(flagPath, "."), sliceValue.GetSlice()); err != nil {
+	if err := mergeFlagValues(configElemValue, flagPath, flagPathJoined, sliceValue.GetSlice()); err != nil {
 		log.Warn().Err(err).Send()
 	}
 }


### PR DESCRIPTION
Build the CLI program with:

```sh
$ make
```

Print the help message:

```sh
$ ./bin/kubeshark__ --help
...
Flags:
      --config-path string   Set the config path, default: /home/mertyildiran/.kubeshark/config.yaml
  -d, --debug                Enable debug mode
  -h, --help                 help for kubeshark
      --set strings          Override values using --set

Use "kubeshark [command] --help" for more information about a command.
```

There are three possible options for the config path;

## Option 1

Usage examples of `--config-path` flag:

```sh
$ ./bin/kubeshark__ config -r --config-path ~/Downloads/kubeshark_config_example.yaml
2025-04-13T00:08:37+03:00 INF versionCheck.go:23 > Checking for a newer version...
2025-04-13T00:08:37+03:00 INF config.go:30 > Template file written to config path. config-path=/home/mertyildiran/Downloads/kubeshark_config_example.yaml
```

```sh
$ ./bin/kubeshark__ config -r --config-path ../kubeshark_config_example.yaml
2025-04-13T00:09:25+03:00 INF versionCheck.go:23 > Checking for a newer version...
2025-04-13T00:09:25+03:00 INF config.go:30 > Template file written to config path. config-path=/home/mertyildiran/Documents/kubeshark/kubeshark_config_example.yaml
```

```sh
$ ./bin/kubeshark__ tap --config-path ../kubeshark_config_example.yaml
2025-04-13T00:11:24+03:00 INF versionCheck.go:23 > Checking for a newer version...
2025-04-13T00:11:24+03:00 INF config.go:189 > Found config file! path=/home/mertyildiran/Documents/kubeshark/kubeshark_config_example.yaml
```

## Option 2

**Without** `--config-path` flag, if `kubeshark.yaml` is **present** in the current working directory:

```sh
$ ./bin/kubeshark__ tap
2025-04-13T00:12:42+03:00 INF versionCheck.go:23 > Checking for a newer version...
2025-04-13T00:12:42+03:00 INF config.go:189 > Found config file! path=/home/mertyildiran/Documents/kubeshark/kubeshark/kubeshark.yaml
```

## Option 3

**Without** `--config-path` flag, if `kubeshark.yaml` is **not present** in the current working directory then defaults to `~/.kubeshark/config.yaml`:

```sh
$ ./bin/kubeshark__ tap
2025-04-13T00:14:15+03:00 INF versionCheck.go:23 > Checking for a newer version...
2025-04-13T00:14:15+03:00 INF config.go:189 > Found config file! path=/home/mertyildiran/.kubeshark/config.yaml
```