### PR TITLE
:hammer: Add `api2BetaEnabled` helm value

### DIFF
--- a/config/configStruct.go
+++ b/config/configStruct.go
@@ -175,6 +175,7 @@ type ConfigStruct struct {
 	AiAssistantEnabled   bool                          `yaml:"aiAssistantEnabled" json:"aiAssistantEnabled" default:"true"`
 	DemoModeEnabled      bool                          `yaml:"demoModeEnabled" json:"demoModeEnabled" default:"false"`
 	SupportChatEnabled   bool                          `yaml:"supportChatEnabled" json:"supportChatEnabled" default:"true"`
+	Api2BetaEnabled      bool                          `yaml:"api2BetaEnabled" json:"api2BetaEnabled" default:"false"`
 	InternetConnectivity bool                          `yaml:"internetConnectivity" json:"internetConnectivity" default:"true"`
 	Scripting            configStructs.ScriptingConfig `yaml:"scripting" json:"scripting"`
 	Manifests            ManifestsConfig               `yaml:"manifests,omitempty" json:"manifests,omitempty"`

--- a/helm-chart/templates/06-front-deployment.yaml
+++ b/helm-chart/templates/06-front-deployment.yaml
@@ -80,6 +80,8 @@ spec:
               value: '{{ .Values.aiAssistantEnabled | ternary "true" "false" }}'
             - name: REACT_APP_SUPPORT_CHAT_ENABLED
               value: '{{ and .Values.supportChatEnabled .Values.internetConnectivity | ternary "true" "false" }}'
+            - name: REACT_APP_API2_BETA_ENABLED
+              value: '{{ .Values.api2BetaEnabled | ternary "true" "false" }}'
             - name: REACT_APP_DISSECTORS_UPDATING_ENABLED
               value: '{{ .Values.tap.liveConfigMapChangesDisabled | ternary "false" "true" }}'
             - name: REACT_APP_SENTRY_ENABLED

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -251,6 +251,7 @@ cloudLicenseEnabled: true
 aiAssistantEnabled: true
 demoModeEnabled: false
 supportChatEnabled: true
+api2BetaEnabled: false
 internetConnectivity: true
 scripting:
   env: {}


### PR DESCRIPTION
Please, refer to corresponding tasks related to API2 architecture.