### PR TITLE
Adding hostNetwork inside values.yaml instead

### DIFF
--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -329,7 +329,7 @@ spec:
               readOnly: true
       {{- end }}
       dnsPolicy: ClusterFirstWithHostNet
-      hostNetwork: true
+      hostNetwork: {{ .Values.hostNetwork }}
       serviceAccountName: {{ include "kubeshark.serviceAccountName" . }}
       {{- if .Values.tap.tolerations.workers }}
       tolerations:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -1,4 +1,6 @@
 # find a detailed description here: https://github.com/kubeshark/kubeshark/blob/master/helm-chart/README.md
+hostNetwork: true
+
 tap:
   docker:
     registry: docker.io/kubeshark

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -1,6 +1,4 @@
 # find a detailed description here: https://github.com/kubeshark/kubeshark/blob/master/helm-chart/README.md
-hostNetwork: true
-
 tap:
   docker:
     registry: docker.io/kubeshark
@@ -78,6 +76,7 @@ tap:
       periodSeconds: 5
       successThreshold: 1
       failureThreshold: 3
+  hostNetwork: true
   serviceMesh: true
   tls: true
   disableTlsLog: true


### PR DESCRIPTION
Ref: https://github.com/kubeshark/kubeshark/issues/1766

In some situations it's desirable not to run this on the host network, eBPF mounts into /sys anyway.