### PR TITLE
chore(helm): use mirror.gcr.io for Kubeshark images to avoid Docker Hub pull limits

### DIFF
--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -1,7 +1,7 @@
 # find a detailed description here: https://github.com/kubeshark/kubeshark/blob/master/helm-chart/README.md
 tap:
   docker:
-    registry: docker.io/kubeshark
+    registry: mirror.gcr.io/kubeshark
     tag: ""
     tagLocked: true
     imagePullPolicy: Always


### PR DESCRIPTION
Docker Hub’s pull‑rate limits keep sending the whole world to **429 jail**:

* **Anonymous:** 100 pulls / 6 h / IP
* **Personal (free, logged‑in):** 200 pulls / 6 h ([Docker Documentation][1])

#### What’s changing

```diff
-    registry: docker.io/kubeshark
+    registry: mirror.gcr.io/kubeshark
```

Only the registry prefix changes—tags/digests stay identical.

#### Why `mirror.gcr.io`?

* **No Hub counting** – pulls are served from Google’s cache, so the Docker Hub limit never triggers.
* **Faster delivery** – images come from Google’s CDN‑backed infra.
* **Extra resilience** – decouples deployments from Docker Hub outages.
