### PR TITLE
Treat 0 value as 0s for dorman timeout

### DIFF
--- a/helm-chart/templates/04-hub-deployment.yaml
+++ b/helm-chart/templates/04-hub-deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - -loglevel
             - '{{ .Values.logLevel | default "warning" }}'
             - -capture-stop-after
-            - "{{ .Values.tap.capture.stopAfter | default "5m" }}"
+            - "{{ if hasKey .Values.tap.capture "stopAfter" }}{{ .Values.tap.capture.stopAfter }}{{ else }}5m{{ end }}"
             {{- if .Values.tap.gitops.enabled }}
             - -gitops
             {{- end }}


### PR DESCRIPTION
Towards https://github.com/kubeshark/hub/issues/406

Current template treats 0 as null and therefore default value is used