### PR TITLE
Fix MCP Registry publish: use OIDC auth for CI

### DIFF
--- a/.github/workflows/mcp-publish.yml
+++ b/.github/workflows/mcp-publish.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Login to MCP Registry
         if: github.event_name != 'workflow_dispatch' || github.event.inputs.dry_run != 'true'
         shell: bash
-        run: mcp-publisher login github
+        run: mcp-publisher login github-oidc
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Switch `mcp-publisher login github` to `mcp-publisher login github-oidc`
- The `github` method uses interactive OAuth device flow (prompts a human to visit a URL), which can never work in CI
- The `github-oidc` method uses the OIDC token provided automatically by GitHub Actions via the `id-token: write` permission

This has never actually worked in CI — the only previous "successful" run was a dry-run that skipped the login step.