### PR TITLE
🔒 Harden security posture and remove api.kubeshark dependencies

### DIFF
--- a/config/configStruct.go
+++ b/config/configStruct.go
@@ -183,8 +183,8 @@ type ConfigStruct struct {
 	DumpLogs             bool                          `yaml:"dumpLogs" json:"dumpLogs" default:"false"`
 	HeadlessMode         bool                          `yaml:"headless" json:"headless" default:"false"`
 	License              string                        `yaml:"license" json:"license" default:""`
-	CloudApiUrl          string                        `yaml:"cloudApiUrl" json:"cloudApiUrl" default:"https://api.kubeshark.com"`
-	CloudLicenseEnabled  bool                          `yaml:"cloudLicenseEnabled" json:"cloudLicenseEnabled" default:"true"`
+	CloudApiUrl          string                        `yaml:"cloudApiUrl" json:"cloudApiUrl" default:""`
+	CloudLicenseEnabled  bool                          `yaml:"cloudLicenseEnabled" json:"cloudLicenseEnabled" default:"false"`
 	DemoModeEnabled      bool                          `yaml:"demoModeEnabled" json:"demoModeEnabled" default:"false"`
 	SupportChatEnabled   bool                          `yaml:"supportChatEnabled" json:"supportChatEnabled" default:"false"`
 	BetaEnabled          bool                          `yaml:"betaEnabled" json:"betaEnabled" default:"false"`

--- a/helm-chart/templates/02-cluster-role.yaml
+++ b/helm-chart/templates/02-cluster-role.yaml
@@ -91,4 +91,8 @@ rules:
     resources:
       - jobs
     verbs:
-      - "*"
+      - create
+      - get
+      - list
+      - watch
+      - delete

--- a/helm-chart/templates/04-hub-deployment.yaml
+++ b/helm-chart/templates/04-hub-deployment.yaml
@@ -23,6 +23,12 @@ spec:
         app.kubeshark.com/app: hub
         {{- include "kubeshark.labels" . | nindent 8 }}
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
       dnsPolicy: ClusterFirstWithHostNet
       serviceAccountName: {{ include "kubeshark.serviceAccountName" . }}
       {{- if .Values.tap.priorityClass }}
@@ -142,6 +148,14 @@ spec:
               {{ if ne (toString .Values.tap.resources.hub.requests.memory) "0" }}
               memory: {{ .Values.tap.resources.hub.requests.memory }}
               {{ end }}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            readOnlyRootFilesystem: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           volumeMounts:
           - name: saml-x509-volume
             mountPath: "/etc/saml/x509"

--- a/helm-chart/templates/06-front-deployment.yaml
+++ b/helm-chart/templates/06-front-deployment.yaml
@@ -22,6 +22,12 @@ spec:
         app.kubeshark.com/app: front
         {{- include "kubeshark.labels" . | nindent 8 }}
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        fsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - env:
             - name: REACT_APP_AUTH_ENABLED
@@ -127,6 +133,14 @@ spec:
             requests:
               cpu: 50m
               memory: 50Mi
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 101
+            readOnlyRootFilesystem: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           volumeMounts:
             - name: nginx-config
               mountPath: /etc/nginx/conf.d/default.conf

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -252,7 +252,7 @@ tap:
     tcpFlowTimeout: 1200
     udpFlowTimeout: 1200
   securityContext:
-    privileged: true
+    privileged: false
     appArmorProfile:
       type: ""
       localhostProfile: ""
@@ -275,7 +275,7 @@ tap:
       - SYS_RESOURCE
       - IPC_LOCK
   mountBpf: true
-  hostNetwork: true
+  hostNetwork: false
 logs:
   file: ""
   grep: ""
@@ -293,8 +293,8 @@ kube:
 dumpLogs: false
 headless: false
 license: ""
-cloudApiUrl: https://api.kubeshark.com
-cloudLicenseEnabled: true
+cloudApiUrl: ""
+cloudLicenseEnabled: false
 demoModeEnabled: false
 supportChatEnabled: false
 betaEnabled: false

--- a/manifests/complete.yaml
+++ b/manifests/complete.yaml
@@ -617,7 +617,7 @@ spec:
             - -capture-db-max-size
             - '500Mi'
             - -cloud-api-url
-            - 'https://api.kubeshark.com'
+            - ''
           image: 'docker.io/kubeshark/worker:v53.1'
           imagePullPolicy: Always
           name: sniffer
@@ -827,7 +827,7 @@ spec:
             - -dissector-memory
             - '4Gi'
             - -cloud-api-url
-            - 'https://api.kubeshark.com'
+            - ''
           env:
           - name: POD_NAME
             valueFrom:


### PR DESCRIPTION
## Summary

This PR addresses critical security vulnerabilities identified in the ArtifactHub security audit and removes external API dependencies:

- **Remove api.kubeshark.com dependency** - Disable `cloudApiUrl` and `cloudLicenseEnabled` by default to eliminate calls to external API
- **Disable privileged mode by default (CRITICAL)** - Changes `securityContext.privileged` from `true` to `false`, activating capability-based security in worker DaemonSet
- **Disable hostNetwork by default (HIGH)** - Reduces network attack surface; eBPF-based capture works without it
- **Add security contexts to hub deployment** - Pod-level and container-level contexts with `runAsNonRoot`, `seccompProfile: RuntimeDefault`, drop all capabilities
- **Add security contexts to front deployment** - Pod-level and container-level contexts with `runAsNonRoot`, `seccompProfile: RuntimeDefault`, drop all capabilities
- **Fix RBAC wildcard permissions** - Replace wildcard `"*"` verbs with explicit permissions: `create`, `get`, `list`, `watch`, `delete`

### Security impact

| Finding | Severity | Status |
|---------|----------|--------|
| Privileged mode default | CRITICAL | ✅ Fixed |
| No security context on hub/front | CRITICAL | ✅ Fixed |
| hostNetwork default | HIGH | ✅ Fixed |
| RBAC wildcard verbs | MEDIUM | ✅ Fixed |
| api.kubeshark.com calls | - | ✅ Removed |

### Breaking changes

Users who require privileged mode or hostNetwork can explicitly opt-in via `values.yaml`:

```yaml
tap:
  securityContext:
    privileged: true
  hostNetwork: true
```

## Files changed

- `config/configStruct.go` - Update default values for cloudApiUrl and cloudLicenseEnabled
- `helm-chart/values.yaml` - Disable privileged, hostNetwork, cloudApiUrl, cloudLicenseEnabled by default
- `helm-chart/templates/02-cluster-role.yaml` - Replace wildcard verbs with explicit permissions
- `helm-chart/templates/04-hub-deployment.yaml` - Add pod and container security contexts
- `helm-chart/templates/06-front-deployment.yaml` - Add pod and container security contexts
- `manifests/complete.yaml` - Remove api.kubeshark.com references

## Test plan

- [ ] Deploy with default values and verify hub/front pods start successfully
- [ ] Verify worker DaemonSet uses capability-based security (not privileged mode)
- [ ] Confirm no external calls to api.kubeshark.com in logs
- [ ] Test basic traffic capture functionality with eBPF
- [ ] Verify RBAC permissions work correctly for job management
- [ ] Test with `privileged: true` override to ensure backward compatibility
- [ ] Validate seccomp and capability restrictions don't break functionality