### PR TITLE
fix: compare semantic versions numerically

### DIFF
--- a/kubernetes/provider_test.go
+++ b/kubernetes/provider_test.go
@@ -1,0 +1,23 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/kubeshark/kubeshark/semver"
+)
+
+func TestValidateKubernetesVersionRejectsNumericVersionBelowMinimum(t *testing.T) {
+	serverVersion := semver.SemVersion("v1.9.0")
+
+	if err := ValidateKubernetesVersion(&serverVersion); err == nil {
+		t.Fatalf("expected Kubernetes version %s to be rejected", serverVersion)
+	}
+}
+
+func TestValidateKubernetesVersionAcceptsMinimumVersion(t *testing.T) {
+	serverVersion := semver.SemVersion(MinKubernetesServerVersion)
+
+	if err := ValidateKubernetesVersion(&serverVersion); err != nil {
+		t.Fatalf("expected Kubernetes version %s to be accepted: %v", serverVersion, err)
+	}
+}

--- a/semver/semver.go
+++ b/semver/semver.go
@@ -2,6 +2,7 @@ package semver
 
 import (
 	"regexp"
+	"strconv"
 )
 
 type SemVersion string
@@ -36,21 +37,34 @@ func (v SemVersion) Patch() string {
 }
 
 func (v SemVersion) GreaterThan(v2 SemVersion) bool {
-	if v.Major() > v2.Major() {
+	vMajor, vMinor, vPatch := v.breakdownInt()
+	v2Major, v2Minor, v2Patch := v2.breakdownInt()
+
+	if vMajor > v2Major {
 		return true
-	} else if v.Major() < v2.Major() {
+	} else if vMajor < v2Major {
 		return false
 	}
 
-	if v.Minor() > v2.Minor() {
+	if vMinor > v2Minor {
 		return true
-	} else if v.Minor() < v2.Minor() {
+	} else if vMinor < v2Minor {
 		return false
 	}
 
-	if v.Patch() > v2.Patch() {
+	if vPatch > v2Patch {
 		return true
 	}
 
 	return false
+}
+
+func (v SemVersion) breakdownInt() (int, int, int) {
+	major, minor, patch := v.Breakdown()
+
+	majorInt, _ := strconv.Atoi(major)
+	minorInt, _ := strconv.Atoi(minor)
+	patchInt, _ := strconv.Atoi(patch)
+
+	return majorInt, minorInt, patchInt
 }

--- a/semver/semver_test.go
+++ b/semver/semver_test.go
@@ -1,0 +1,51 @@
+package semver
+
+import "testing"
+
+func TestGreaterThanComparesNumericComponents(t *testing.T) {
+	tests := []struct {
+		name string
+		v1   SemVersion
+		v2   SemVersion
+		want bool
+	}{
+		{
+			name: "minor component with fewer digits",
+			v1:   "1.16.0",
+			v2:   "1.9.0",
+			want: true,
+		},
+		{
+			name: "patch component with fewer digits",
+			v1:   "1.16.10",
+			v2:   "1.16.9",
+			want: true,
+		},
+		{
+			name: "lower major component",
+			v1:   "1.30.0",
+			v2:   "2.0.0",
+			want: false,
+		},
+		{
+			name: "same version",
+			v1:   "1.16.0",
+			v2:   "1.16.0",
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.v1.GreaterThan(test.v2); got != test.want {
+				t.Fatalf("%s.GreaterThan(%s) = %t, want %t", test.v1, test.v2, got, test.want)
+			}
+		})
+	}
+}
+
+func TestGreaterThanSupportsKubernetesGitVersionPrefix(t *testing.T) {
+	if !SemVersion("v1.16.0").GreaterThan("v1.9.0") {
+		t.Fatal("expected v1.16.0 to be greater than v1.9.0")
+	}
+}


### PR DESCRIPTION
## What
Fixes SemVersion.GreaterThan so version parts compare as numbers, not strings. Small footgun, but it made v1.16.0 look not greater than v1.9.0, yikes.

## Repro
On old code:
```sh
go test ./semver -run TestGreaterThan -v
```

The bad bit was:
```
1.16.0.GreaterThan(1.9.0) = false, want true
1.16.10.GreaterThan(1.16.9) = false, want true
```

## Checks
`make test` passes.