### PR TITLE
Enable tlsx dissector by default

### DIFF
--- a/config/configStruct.go
+++ b/config/configStruct.go
@@ -135,7 +135,7 @@ func CreateDefaultConfig() ConfigStruct {
 				// "tcp",
 				// "udp",
 				"ws",
-				// "tlsx",
+				"tlsx",
 				"ldap",
 				"radius",
 				"diameter",


### PR DESCRIPTION
## Summary

Uncomments `tlsx` in the default enabled dissectors list. The TLS handshake dissector captures ClientHello and ServerHello messages for security auditing, egress monitoring via SNI, and JA3 fingerprinting.

Related PRs: kubeshark/worker#1153, kubeshark/front#1228, kubeshark/kfl2#30, kubeshark/docs#104