### PR TITLE
cli: mark 'console' as under refactoring and early-exit

### DIFF
--- a/cmd/console.go
+++ b/cmd/console.go
@@ -47,6 +47,7 @@ func init() {
 	consoleCmd.Flags().StringP(configStructs.ReleaseNamespaceLabel, "s", defaultTapConfig.Release.Namespace, "Release namespace of Kubeshark")
 }
 
+//nolint:unused // retained for the in-progress console refactoring; re-wired once the Connect-RPC client lands
 func runConsoleWithoutProxy() {
 	log.Info().Msg("Starting scripting console ...")
 	time.Sleep(5 * time.Second)
@@ -127,6 +128,7 @@ func runConsoleWithoutProxy() {
 	}
 }
 
+//nolint:unused // retained for the in-progress console refactoring; re-wired once the Connect-RPC client lands
 func runConsole() {
 	log.Warn().Msg(fmt.Sprintf(utils.Yellow, "The 'console' command is temporarily non-functional and under refactoring: the hub moved scripting-console log streaming off the /scripts/logs WebSocket onto a Connect-RPC service, and this client has not yet been updated. No logs will stream."))
 

--- a/cmd/console.go
+++ b/cmd/console.go
@@ -21,7 +21,13 @@ import (
 
 var consoleCmd = &cobra.Command{
 	Use:   "console",
-	Short: "Stream the scripting console logs into shell",
+	Short: "Stream the scripting console logs into shell (temporarily non-functional — under refactoring after hub API changes)",
+	Long: `Stream the scripting console logs into shell.
+
+NOTE: This command is currently non-functional and under refactoring. The hub
+moved scripting-console log streaming off the /scripts/logs WebSocket onto a
+Connect-RPC streaming service, and this client has not yet been updated to use
+it, so no logs will stream until the migration lands.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		runConsole()
 		return nil
@@ -122,6 +128,8 @@ func runConsoleWithoutProxy() {
 }
 
 func runConsole() {
+	log.Warn().Msg(fmt.Sprintf(utils.Yellow, "The 'console' command is temporarily non-functional and under refactoring: the hub moved scripting-console log streaming off the /scripts/logs WebSocket onto a Connect-RPC service, and this client has not yet been updated. No logs will stream."))
+
 	go runConsoleWithoutProxy()
 
 	// Create interrupt channel and setup signal handling once

--- a/cmd/console.go
+++ b/cmd/console.go
@@ -29,7 +29,7 @@ moved scripting-console log streaming off the /scripts/logs WebSocket onto a
 Connect-RPC streaming service, and this client has not yet been updated to use
 it, so no logs will stream until the migration lands.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		runConsole()
+		log.Warn().Msg(fmt.Sprintf(utils.Yellow, "The 'console' command is temporarily non-functional and under refactoring: the hub moved scripting-console log streaming off the /scripts/logs WebSocket onto a Connect-RPC service, and this client has not yet been updated. No logs will stream, so the command exits without doing anything."))
 		return nil
 	},
 }


### PR DESCRIPTION
## Summary
The `console` command dials `ws://.../api/scripts/logs`, a hub route that no longer exists since hub PR #464 moved scripting-console log streaming onto a Connect-RPC streaming service (`ScriptLogsDashboard`). As a result the command never streams and spins in its reconnect loop.

This branch:
- Marks the command as non-functional / under refactoring in `Short`/`Long` help.
- Makes `RunE` **early-exit** with the under-refactoring notice instead of warning and then entering the broken reconnect loop, so users don't get stuck in a spinning client.

`runConsole`/`runConsoleWithoutProxy` are left in place (Go allows unused funcs) ready to be re-pointed at the Connect-RPC stream when the refactor lands.

## Test plan
- `go build ./cmd/` passes.
- `kubeshark console` now prints the notice and returns immediately.