### PR TITLE
helm: gate the worker hub token on the same condition as AUTH_ENABLED

### DIFF
--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -284,6 +284,10 @@ spec:
             value: '{{ (include "sentry.enabled" .) }}'
           - name: SENTRY_ENVIRONMENT
             value: '{{ .Values.tap.sentry.environment }}'
+          {{- if eq (include "kubeshark.authEnabled" .) "true" }}
+          - name: HUB_INTERNAL_TOKEN_PATH
+            value: /var/run/secrets/kubeshark/hub-token/token
+          {{- end }}
           resources:
             limits:
               {{ if ne (toString .Values.tap.resources.tracer.limits.cpu) "0" }}
@@ -359,6 +363,11 @@ spec:
               mountPropagation: HostToContainer
               name: root
               readOnly: true
+            {{- if eq (include "kubeshark.authEnabled" .) "true" }}
+            - mountPath: /var/run/secrets/kubeshark/hub-token
+              name: hub-internal-token
+              readOnly: true
+            {{- end }}
       {{- end }}
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: {{ .Values.tap.hostNetwork }}

--- a/helm-chart/templates/09-worker-daemon-set.yaml
+++ b/helm-chart/templates/09-worker-daemon-set.yaml
@@ -146,7 +146,7 @@ spec:
             value: '{{ (include "sentry.enabled" .) }}'
           - name: SENTRY_ENVIRONMENT
             value: '{{ .Values.tap.sentry.environment }}'
-          {{- if (((.Values.tap).auth).enabled) }}
+          {{- if eq (include "kubeshark.authEnabled" .) "true" }}
           - name: HUB_INTERNAL_TOKEN_PATH
             value: /var/run/secrets/kubeshark/hub-token/token
           {{- end }}
@@ -239,7 +239,7 @@ spec:
 {{- if .Values.tap.persistentStorage }}
               subPathExpr: $(NODE_NAME)
 {{- end }}
-            {{- if (((.Values.tap).auth).enabled) }}
+            {{- if eq (include "kubeshark.authEnabled" .) "true" }}
             - mountPath: /var/run/secrets/kubeshark/hub-token
               name: hub-internal-token
               readOnly: true
@@ -439,7 +439,7 @@ spec:
           emptyDir:
             sizeLimit: {{ .Values.tap.storageLimit }}
 {{- end }}
-        {{- if (((.Values.tap).auth).enabled) }}
+        {{- if eq (include "kubeshark.authEnabled" .) "true" }}
         - name: hub-internal-token
           projected:
             sources:

--- a/helm-chart/templates/12-config-map.yaml
+++ b/helm-chart/templates/12-config-map.yaml
@@ -18,11 +18,7 @@ data:
     INGRESS_ENABLED: '{{ .Values.tap.ingress.enabled }}'
     INGRESS_HOST: '{{ .Values.tap.ingress.host }}'
     PROXY_FRONT_PORT: '{{ .Values.tap.proxy.front.port }}'
-    AUTH_ENABLED: '{{- if and .Values.cloudLicenseEnabled (not (empty .Values.license)) -}}
-                        {{ (default false .Values.demoModeEnabled) | ternary true ((and .Values.tap.auth.enabled (or (eq .Values.tap.auth.type "oidc") (eq .Values.tap.auth.type "dex"))) | ternary true false) }}
-                  {{- else -}}
-                        {{ .Values.cloudLicenseEnabled | ternary "true" ((default false .Values.demoModeEnabled) | ternary "true" .Values.tap.auth.enabled) }}
-                  {{- end }}'
+    AUTH_ENABLED: '{{ include "kubeshark.authEnabled" . }}'
     AUTH_TYPE: '{{- if and .Values.cloudLicenseEnabled (not (or (eq .Values.tap.auth.type "oidc") (eq .Values.tap.auth.type "dex"))) -}}
                   default
                 {{- else -}}

--- a/helm-chart/templates/_helpers.tpl
+++ b/helm-chart/templates/_helpers.tpl
@@ -110,3 +110,17 @@ Dex IdP: retrieve a secret for static client with a specific ID
     {{- end }}
   {{- end }}
 {{- end }}
+
+{{/*
+Single source of truth for whether the hub enforces authentication.
+Consumed by the hub ConfigMap (AUTH_ENABLED) and by the worker DaemonSet, which
+must mount an internal hub token whenever the hub requires one. Keeping the two
+in sync prevents workers from being issued no token while the hub demands one.
+*/}}
+{{- define "kubeshark.authEnabled" -}}
+{{- if and .Values.cloudLicenseEnabled (not (empty .Values.license)) -}}
+{{ (default false .Values.demoModeEnabled) | ternary true ((and .Values.tap.auth.enabled (or (eq .Values.tap.auth.type "oidc") (eq .Values.tap.auth.type "dex"))) | ternary true false) }}
+{{- else -}}
+{{ .Values.cloudLicenseEnabled | ternary "true" ((default false .Values.demoModeEnabled) | ternary "true" .Values.tap.auth.enabled) }}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
Fixes #1954 (chart half).

## The bug

The hub's `AUTH_ENABLED` is derived from `cloudLicenseEnabled` / `demoModeEnabled` / `tap.auth.enabled`, but the worker DaemonSet gated `HUB_INTERNAL_TOKEN_PATH`, its volumeMount and the projected `serviceAccountToken` on `tap.auth.enabled` **alone**. With `demoModeEnabled: true` and `tap.auth.enabled` unset the hub demanded a bearer token the workers never received, and every worker → hub call returned 401.

Note this is not limited to demo mode: `cloudLicenseEnabled` defaults to `true`, so `helm template` with stock values already produces `AUTH_ENABLED: 'true'` and no token.

## Changes

1. **`kubeshark.authEnabled` helper** — the `AUTH_ENABLED` expression extracted verbatim into `_helpers.tpl`, consumed by both `12-config-map.yaml` and `09-worker-daemon-set.yaml` so the two cannot drift again.
2. **Token wiring in the tracer container too** — the tracer polls `/pods/all` and `/pods/targeted` on every sync cycle, but only the sniffer container got the env var and mount.

## Draft, because

The tracer container change is inert without kubeshark/tracer2#68, which teaches the tracer to send the header. The helper change stands on its own and fixes the resolver 401s.

## Testing

- `helm template` across all 48 combinations of `cloudLicenseEnabled` × `license` × `demoModeEnabled` × `tap.auth.enabled` × `tap.auth.type`: `AUTH_ENABLED` renders byte-identical to master in every one. Only the worker token wiring changes.
- With `tap.tls=true` both containers get `HUB_INTERNAL_TOKEN_PATH` + the mount; with `tap.tls=false` only the sniffer, as before.
- `helm lint` clean.