### PR TITLE
helm: use Recreate strategy for hub Deployment when local snapshots PVC is set

### DIFF
--- a/helm-chart/templates/04-hub-deployment.yaml
+++ b/helm-chart/templates/04-hub-deployment.yaml
@@ -13,6 +13,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1  # Set the desired number of replicas
+  {{- if .Values.tap.snapshots.local.storageClass }}
+  strategy:
+    type: Recreate  # avoid RWO snapshots PVC attach deadlock on upgrade (#1953)
+  {{- end }}
   selector:
     matchLabels:
       app.kubeshark.com/app: hub

--- a/helm-chart/tests/hub_deployment_test.yaml
+++ b/helm-chart/tests/hub_deployment_test.yaml
@@ -135,6 +135,19 @@ tests:
             secretRef:
               name: my-existing-secret
 
+  - it: should not set Recreate strategy by default (emptyDir snapshots)
+    asserts:
+      - isNull:
+          path: spec.strategy
+
+  - it: should set Recreate strategy when local snapshots storageClass is set
+    set:
+      tap.snapshots.local.storageClass: standard
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: Recreate
+
   - it: should render both inline and external refs together
     set:
       tap.snapshots.cloud.s3.bucket: my-bucket


### PR DESCRIPTION

When tap.snapshots.local.storageClass is set, the hub mounts a ReadWriteOnce snapshots PVC but keeps the default RollingUpdate strategy, so an upgrade deadlocks: the new pod cannot attach the RWO volume still held by the old running pod, yet helm reports success. Guard a strategy.type: Recreate on the same condition that switches the snapshots volume to the RWO PVC. Default (emptyDir) is unchanged.

Fixes #1953