### PR TITLE
:bookmark: Release v53.4.0

### DIFF
--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: kubeshark
-version: "53.3.0"
+version: "53.4.0"
 description: The API Traffic Analyzer for Kubernetes
 home: https://kubeshark.com
 keywords:

--- a/manifests/complete.yaml
+++ b/manifests/complete.yaml
@@ -4,10 +4,10 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   labels:
-    helm.sh/chart: kubeshark-53.3.0
+    helm.sh/chart: kubeshark-53.4.0
     app.kubernetes.io/name: kubeshark
     app.kubernetes.io/instance: kubeshark
-    app.kubernetes.io/version: "53.3.0"
+    app.kubernetes.io/version: "53.4.0"
     app.kubernetes.io/managed-by: Helm
   name: kubeshark-hub-network-policy
   namespace: default
@@ -33,10 +33,10 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   labels:
-    helm.sh/chart: kubeshark-53.3.0
+    helm.sh/chart: kubeshark-53.4.0
     app.kubernetes.io/name: kubeshark
     app.kubernetes.io/instance: kubeshark
-    app.kubernetes.io/version: "53.3.0"
+    app.kubernetes.io/version: "53.4.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
   name: kubeshark-front-network-policy
@@ -60,10 +60,10 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   labels:
-    helm.sh/chart: kubeshark-53.3.0
+    helm.sh/chart: kubeshark-53.4.0
     app.kubernetes.io/name: kubeshark
     app.kubernetes.io/instance: kubeshark
-    app.kubernetes.io/version: "53.3.0"
+    app.kubernetes.io/version: "53.4.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
   name: kubeshark-dex-network-policy
@@ -87,10 +87,10 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   labels:
-    helm.sh/chart: kubeshark-53.3.0
+    helm.sh/chart: kubeshark-53.4.0
     app.kubernetes.io/name: kubeshark
     app.kubernetes.io/instance: kubeshark
-    app.kubernetes.io/version: "53.3.0"
+    app.kubernetes.io/version: "53.4.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
   name: kubeshark-worker-network-policy
@@ -116,10 +116,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: kubeshark-53.3.0
+    helm.sh/chart: kubeshark-53.4.0
     app.kubernetes.io/name: kubeshark
     app.kubernetes.io/instance: kubeshark
-    app.kubernetes.io/version: "53.3.0"
+    app.kubernetes.io/version: "53.4.0"
     app.kubernetes.io/managed-by: Helm
   name: kubeshark-service-account
   namespace: default
@@ -132,10 +132,10 @@ metadata:
   namespace: default
   labels:
     app.kubeshark.com/app: hub
-    helm.sh/chart: kubeshark-53.3.0
+    helm.sh/chart: kubeshark-53.4.0
     app.kubernetes.io/name: kubeshark
     app.kubernetes.io/instance: kubeshark
-    app.kubernetes.io/version: "53.3.0"
+    app.kubernetes.io/version: "53.4.0"
     app.kubernetes.io/managed-by: Helm
 stringData:
     LICENSE: ''
@@ -151,10 +151,10 @@ metadata:
   namespace: default
   labels:
     app.kubeshark.com/app: hub
-    helm.sh/chart: kubeshark-53.3.0
+    helm.sh/chart: kubeshark-53.4.0
     app.kubernetes.io/name: kubeshark
     app.kubernetes.io/instance: kubeshark
-    app.kubernetes.io/version: "53.3.0"
+    app.kubernetes.io/version: "53.4.0"
     app.kubernetes.io/managed-by: Helm
 stringData:
   AUTH_SAML_X509_CRT: |
@@ -167,10 +167,10 @@ metadata:
   namespace: default
   labels:
     app.kubeshark.com/app: hub
-    helm.sh/chart: kubeshark-53.3.0
+    helm.sh/chart: kubeshark-53.4.0
     app.kubernetes.io/name: kubeshark
     app.kubernetes.io/instance: kubeshark
-    app.kubernetes.io/version: "53.3.0"
+    app.kubernetes.io/version: "53.4.0"
     app.kubernetes.io/managed-by: Helm
 stringData:
   AUTH_SAML_X509_KEY: |
@@ -182,10 +182,10 @@ metadata:
   name: kubeshark-nginx-config-map
   namespace: default
   labels:
-    helm.sh/chart: kubeshark-53.3.0
+    helm.sh/chart: kubeshark-53.4.0
     app.kubernetes.io/name: kubeshark
     app.kubernetes.io/instance: kubeshark
-    app.kubernetes.io/version: "53.3.0"
+    app.kubernetes.io/version: "53.4.0"
     app.kubernetes.io/managed-by: Helm
 data:
   default.conf: |
@@ -252,10 +252,10 @@ metadata:
   namespace: default
   labels:
     app.kubeshark.com/app: hub
-    helm.sh/chart: kubeshark-53.3.0
+    helm.sh/chart: kubeshark-53.4.0
     app.kubernetes.io/name: kubeshark
     app.kubernetes.io/instance: kubeshark
-    app.kubernetes.io/version: "53.3.0"
+    app.kubernetes.io/version: "53.4.0"
     app.kubernetes.io/managed-by: Helm
 data:
     POD_REGEX: '.*'
@@ -272,9 +272,11 @@ data:
     AUTH_ENABLED: 'true'
     AUTH_TYPE: 'default'
     AUTH_SAML_IDP_METADATA_URL: ''
-    AUTH_ROLES: '{"admin":{"canControlDissection":true,"canDownloadPCAP":true,"canStopTrafficCapturing":true,"canUpdateTargetedPods":true,"canUseScripting":true,"filter":"","scriptingPermissions":{"canActivate":true,"canDelete":true,"canSave":true},"showAdminConsoleLink":true}}'
-    AUTH_ROLES_CLAIM: 'role'
-    AUTH_DEFAULT_ROLE: ''
+    AUTH_CLI_SERVICE_ACCOUNTS: ''
+    AUTH_ROLES_CLAIM: 'groups'
+    AUTH_DEFAULT_ROLE: 'kubeshark-viewer'
+    AUTH_GROUP_MAPPING: '{}'
+    AUTH_ROLES: '{}'
     AUTH_OIDC_ISSUER: 'not set'
     AUTH_OIDC_REFRESH_TOKEN_LIFETIME: '3960h'
     AUTH_OIDC_STATE_PARAM_EXPIRY: '10m'
@@ -313,10 +315,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: kubeshark-53.3.0
+    helm.sh/chart: kubeshark-53.4.0
     app.kubernetes.io/name: kubeshark
     app.kubernetes.io/instance: kubeshark
-    app.kubernetes.io/version: "53.3.0"
+    app.kubernetes.io/version: "53.4.0"
     app.kubernetes.io/managed-by: Helm
   name: kubeshark-cluster-role-default
   namespace: default
@@ -366,10 +368,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: kubeshark-53.3.0
+    helm.sh/chart: kubeshark-53.4.0
     app.kubernetes.io/name: kubeshark
     app.kubernetes.io/instance: kubeshark
-    app.kubernetes.io/version: "53.3.0"
+    app.kubernetes.io/version: "53.4.0"
     app.kubernetes.io/managed-by: Helm
   name: kubeshark-cluster-role-binding-default
   namespace: default
@@ -387,10 +389,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: kubeshark-53.3.0
+    helm.sh/chart: kubeshark-53.4.0
     app.kubernetes.io/name: kubeshark
     app.kubernetes.io/instance: kubeshark
-    app.kubernetes.io/version: "53.3.0"
+    app.kubernetes.io/version: "53.4.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
   name: kubeshark-self-config-role
@@ -446,10 +448,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: kubeshark-53.3.0
+    helm.sh/chart: kubeshark-53.4.0
     app.kubernetes.io/name: kubeshark
     app.kubernetes.io/instance: kubeshark
-    app.kubernetes.io/version: "53.3.0"
+    app.kubernetes.io/version: "53.4.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
   name: kubeshark-self-config-role-binding
@@ -469,10 +471,10 @@ kind: Service
 metadata:
   labels:
     app.kubeshark.com/app: hub
-    helm.sh/chart: kubeshark-53.3.0
+    helm.sh/chart: kubeshark-53.4.0
     app.kubernetes.io/name: kubeshark
     app.kubernetes.io/instance: kubeshark
-    app.kubernetes.io/version: "53.3.0"
+    app.kubernetes.io/version: "53.4.0"
     app.kubernetes.io/managed-by: Helm
   name: kubeshark-hub
   namespace: default
@@ -490,10 +492,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: kubeshark-53.3.0
+    helm.sh/chart: kubeshark-53.4.0
     app.kubernetes.io/name: kubeshark
     app.kubernetes.io/instance: kubeshark
-    app.kubernetes.io/version: "53.3.0"
+    app.kubernetes.io/version: "53.4.0"
     app.kubernetes.io/managed-by: Helm
   name: kubeshark-front
   namespace: default
@@ -511,10 +513,10 @@ kind: Service
 apiVersion: v1
 metadata:
   labels:
-    helm.sh/chart: kubeshark-53.3.0
+    helm.sh/chart: kubeshark-53.4.0
     app.kubernetes.io/name: kubeshark
     app.kubernetes.io/instance: kubeshark
-    app.kubernetes.io/version: "53.3.0"
+    app.kubernetes.io/version: "53.4.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     prometheus.io/scrape: 'true'
@@ -524,10 +526,10 @@ metadata:
 spec:
   selector:
     app.kubeshark.com/app: worker
-    helm.sh/chart: kubeshark-53.3.0
+    helm.sh/chart: kubeshark-53.4.0
     app.kubernetes.io/name: kubeshark
     app.kubernetes.io/instance: kubeshark
-    app.kubernetes.io/version: "53.3.0"
+    app.kubernetes.io/version: "53.4.0"
     app.kubernetes.io/managed-by: Helm
   ports:
   - name: metrics
@@ -540,10 +542,10 @@ kind: Service
 apiVersion: v1
 metadata:
   labels:
-    helm.sh/chart: kubeshark-53.3.0
+    helm.sh/chart: kubeshark-53.4.0
     app.kubernetes.io/name: kubeshark
     app.kubernetes.io/instance: kubeshark
-    app.kubernetes.io/version: "53.3.0"
+    app.kubernetes.io/version: "53.4.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     prometheus.io/scrape: 'true'
@@ -553,10 +555,10 @@ metadata:
 spec:
   selector:
     app.kubeshark.com/app: hub
-    helm.sh/chart: kubeshark-53.3.0
+    helm.sh/chart: kubeshark-53.4.0
     app.kubernetes.io/name: kubeshark
     app.kubernetes.io/instance: kubeshark
-    app.kubernetes.io/version: "53.3.0"
+    app.kubernetes.io/version: "53.4.0"
     app.kubernetes.io/managed-by: Helm
   ports:
   - name: metrics
@@ -571,10 +573,10 @@ metadata:
   labels:
     app.kubeshark.com/app: worker
     sidecar.istio.io/inject: "false"
-    helm.sh/chart: kubeshark-53.3.0
+    helm.sh/chart: kubeshark-53.4.0
     app.kubernetes.io/name: kubeshark
     app.kubernetes.io/instance: kubeshark
-    app.kubernetes.io/version: "53.3.0"
+    app.kubernetes.io/version: "53.4.0"
     app.kubernetes.io/managed-by: Helm
   name: kubeshark-worker-daemon-set
   namespace: default
@@ -589,10 +591,10 @@ spec:
       labels:
         app.kubeshark.com/app: worker
         kubeshark.io/internal-auth: "true"
-        helm.sh/chart: kubeshark-53.3.0
+        helm.sh/chart: kubeshark-53.4.0
         app.kubernetes.io/name: kubeshark
         app.kubernetes.io/instance: kubeshark
-        app.kubernetes.io/version: "53.3.0"
+        app.kubernetes.io/version: "53.4.0"
         app.kubernetes.io/managed-by: Helm
       name: kubeshark-worker-daemon-set
       namespace: kubeshark
@@ -602,7 +604,7 @@ spec:
           - /bin/sh
           - -c
           - mkdir -p /sys/fs/bpf && mount | grep -q '/sys/fs/bpf' || mount -t bpf bpf /sys/fs/bpf
-          image: 'docker.io/kubeshark/worker:v53.3'
+          image: 'docker.io/kubeshark/worker:v53.4'
           imagePullPolicy: Always
           name: mount-bpf
           securityContext:
@@ -641,7 +643,7 @@ spec:
             - '500Mi'
             - -cloud-api-url
             - 'https://api.kubeshark.com'
-          image: 'docker.io/kubeshark/worker:v53.3'
+          image: 'docker.io/kubeshark/worker:v53.4'
           imagePullPolicy: Always
           name: sniffer
           ports:
@@ -671,6 +673,8 @@ spec:
             value: 'false'
           - name: SENTRY_ENVIRONMENT
             value: 'production'
+          - name: HUB_INTERNAL_TOKEN_PATH
+            value: /var/run/secrets/kubeshark/hub-token/token
           resources:
             limits:
               
@@ -710,6 +714,9 @@ spec:
               mountPropagation: HostToContainer
             - mountPath: /app/data
               name: data
+            - mountPath: /var/run/secrets/kubeshark/hub-token
+              name: hub-internal-token
+              readOnly: true
         - command:
             - ./tracer
             - -procfs
@@ -717,7 +724,7 @@ spec:
             - -disable-tls-log
             - -loglevel
             - 'warning'
-          image: 'docker.io/kubeshark/worker:v53.3'
+          image: 'docker.io/kubeshark/worker:v53.4'
           imagePullPolicy: Always
           name: tracer
           env:
@@ -739,6 +746,8 @@ spec:
             value: 'false'
           - name: SENTRY_ENVIRONMENT
             value: 'production'
+          - name: HUB_INTERNAL_TOKEN_PATH
+            value: /var/run/secrets/kubeshark/hub-token/token
           resources:
             limits:
               
@@ -770,6 +779,9 @@ spec:
             - mountPath: /hostroot
               mountPropagation: HostToContainer
               name: root
+              readOnly: true
+            - mountPath: /var/run/secrets/kubeshark/hub-token
+              name: hub-internal-token
               readOnly: true
       dnsPolicy: ClusterFirstWithHostNet
       hostNetwork: true
@@ -806,6 +818,13 @@ spec:
         - name: data
           emptyDir:
             sizeLimit: 10Gi
+        - name: hub-internal-token
+          projected:
+            sources:
+              - serviceAccountToken:
+                  path: token
+                  audience: kubeshark-hub
+                  expirationSeconds: 3600
 ---
 # Source: kubeshark/templates/04-hub-deployment.yaml
 apiVersion: apps/v1
@@ -813,10 +832,10 @@ kind: Deployment
 metadata:
   labels:
     app.kubeshark.com/app: hub
-    helm.sh/chart: kubeshark-53.3.0
+    helm.sh/chart: kubeshark-53.4.0
     app.kubernetes.io/name: kubeshark
     app.kubernetes.io/instance: kubeshark
-    app.kubernetes.io/version: "53.3.0"
+    app.kubernetes.io/version: "53.4.0"
     app.kubernetes.io/managed-by: Helm
   name: kubeshark-hub
   namespace: default
@@ -831,10 +850,10 @@ spec:
     metadata:
       labels:
         app.kubeshark.com/app: hub
-        helm.sh/chart: kubeshark-53.3.0
+        helm.sh/chart: kubeshark-53.4.0
         app.kubernetes.io/name: kubeshark
         app.kubernetes.io/instance: kubeshark
-        app.kubernetes.io/version: "53.3.0"
+        app.kubernetes.io/version: "53.4.0"
         app.kubernetes.io/managed-by: Helm
     spec:
       dnsPolicy: ClusterFirstWithHostNet
@@ -852,7 +871,7 @@ spec:
             - -snapshot-size-limit
             - '20Gi'
             - -dissector-image
-            - 'docker.io/kubeshark/worker:v53.3'
+            - 'docker.io/kubeshark/worker:v53.4'
             - -dissector-cpu
             - '1'
             - -dissector-memory
@@ -876,7 +895,7 @@ spec:
             value: 'production'
           - name: PROFILING_ENABLED
             value: 'false'
-          image: 'docker.io/kubeshark/hub:v53.3'
+          image: 'docker.io/kubeshark/hub:v53.4'
           imagePullPolicy: Always
           readinessProbe:
             periodSeconds: 5
@@ -944,10 +963,10 @@ kind: Deployment
 metadata:
   labels:
     app.kubeshark.com/app: front
-    helm.sh/chart: kubeshark-53.3.0
+    helm.sh/chart: kubeshark-53.4.0
     app.kubernetes.io/name: kubeshark
     app.kubernetes.io/instance: kubeshark
-    app.kubernetes.io/version: "53.3.0"
+    app.kubernetes.io/version: "53.4.0"
     app.kubernetes.io/managed-by: Helm
   name: kubeshark-front
   namespace: default
@@ -962,10 +981,10 @@ spec:
     metadata:
       labels:
         app.kubeshark.com/app: front
-        helm.sh/chart: kubeshark-53.3.0
+        helm.sh/chart: kubeshark-53.4.0
         app.kubernetes.io/name: kubeshark
         app.kubernetes.io/instance: kubeshark
-        app.kubernetes.io/version: "53.3.0"
+        app.kubernetes.io/version: "53.4.0"
         app.kubernetes.io/managed-by: Helm
     spec:
       containers:
@@ -1020,7 +1039,7 @@ spec:
               value: 'false'
             - name: REACT_APP_SENTRY_ENVIRONMENT
               value: 'production'
-          image: 'docker.io/kubeshark/front:v53.3'
+          image: 'docker.io/kubeshark/front:v53.4'
           imagePullPolicy: Always
           name: kubeshark-front
           livenessProbe:


### PR DESCRIPTION
Release v53.4.0. Bumps the Helm chart version and regenerates `helm-chart/values.yaml` and `manifests/complete.yaml`.