### PR TITLE
feat: validate configuration schema version

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,28 @@
+# Configuration schema versioning
+
+The top-level `version` value identifies the CLI configuration schema. It is
+independent of the Kubeshark release version: compatible application releases
+must continue to use the same schema version.
+
+## Compatibility rules
+
+- Files without `version` predate schema versioning and are treated as schema
+  version 1.
+- The CLI loads only the schema version it explicitly supports. An incompatible
+  file produces an error that points to `kubeshark config -r`.
+- `kubeshark config -r` does not load the file it replaces, so regeneration also
+  works for malformed or incompatible configurations.
+- Writers always stamp the current version and never mutate the caller's config.
+- The loader decodes once into a temporary copy and replaces the runtime config
+  only after validation succeeds. Invalid files cannot leave partial changes.
+
+## Changing the schema
+
+Do not increment `currentConfigVersion` for additive or otherwise compatible
+changes. Increment it only when loading the previous schema would be unsafe or
+ambiguous. Keep the initial version unchanged so unversioned legacy files retain
+their original meaning.
+
+Keep compatibility checks at the file-loading boundary instead of scattering
+version conditions across command code. Add table-driven tests for the current,
+legacy, malformed, older, and newer formats whenever the policy changes.

--- a/config/config.go
+++ b/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -18,6 +17,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/kubeshark/kubeshark/config/configStructs"
 	"github.com/kubeshark/kubeshark/misc"
 	"github.com/kubeshark/kubeshark/misc/version"
 	"github.com/kubeshark/kubeshark/utils"
@@ -86,13 +86,13 @@ func InitConfig(cmd *cobra.Command) error {
 	}
 
 	ConfigFilePath = GetConfigFilePath(cmd)
-	if err := loadConfigFile(&Config, utils.Contains([]string{
+	if err := loadConfigFileForCommand(&Config, cmd, utils.Contains([]string{
 		"manifests",
 		"license",
 	}, cmd.Use)); err != nil {
 		if !os.IsNotExist(err) {
 			return fmt.Errorf("invalid config, %w\n"+
-				"you can regenerate the file by removing it (%v) and using `kubeshark config -r`", err, ConfigFilePath)
+				"you can regenerate the file (%v) using `kubeshark config -r`", err, ConfigFilePath)
 		}
 	}
 
@@ -108,6 +108,7 @@ func GetConfigWithDefaults() (*ConfigStruct, error) {
 	if err := defaults.Set(&defaultConf); err != nil {
 		return nil, err
 	}
+	defaultConf.Version = currentConfigVersion
 
 	configElem := reflect.ValueOf(&defaultConf).Elem()
 	setZeroForReadonlyFields(configElem)
@@ -116,7 +117,10 @@ func GetConfigWithDefaults() (*ConfigStruct, error) {
 }
 
 func WriteConfig(config *ConfigStruct) error {
-	template, err := utils.PrettyYaml(config)
+	configToWrite := *config
+	configToWrite.Version = currentConfigVersion
+
+	template, err := utils.PrettyYaml(&configToWrite)
 	if err != nil {
 		return fmt.Errorf("failed converting config to yaml, err: %v", err)
 	}
@@ -172,23 +176,66 @@ func GetConfigFilePath(cmd *cobra.Command) string {
 }
 
 func loadConfigFile(config *ConfigStruct, silent bool) error {
-	reader, err := os.Open(ConfigFilePath)
-	if err != nil {
-		return err
-	}
-	defer reader.Close()
-
-	buf, err := io.ReadAll(reader)
+	data, err := os.ReadFile(ConfigFilePath)
 	if err != nil {
 		return err
 	}
 
-	if err := yaml.Unmarshal(buf, config); err != nil {
+	loadedConfig, err := decodeConfig(data, *config)
+	if err != nil {
 		return err
 	}
+	*config = loadedConfig
 
 	if !silent {
 		log.Info().Str("path", ConfigFilePath).Msg("Found config file!")
+	}
+
+	return nil
+}
+
+func loadConfigFileForCommand(config *ConfigStruct, cmd *cobra.Command, silent bool) error {
+	if cmd.Name() == "config" {
+		regenerate, err := cmd.Flags().GetBool(configStructs.RegenerateConfigName)
+		if err != nil {
+			return fmt.Errorf("failed reading --%s flag: %w", configStructs.RegenerateConfigName, err)
+		}
+
+		// Regeneration must work even when the existing file is malformed or uses an
+		// unsupported schema; the command replaces that file instead of consuming it.
+		if regenerate {
+			return nil
+		}
+	}
+
+	return loadConfigFile(config, silent)
+}
+
+func decodeConfig(data []byte, base ConfigStruct) (ConfigStruct, error) {
+	// Start with the implicit legacy version so an omitted field keeps its original
+	// meaning after currentConfigVersion is incremented in the future.
+	base.Version = initialConfigVersion
+	if err := yaml.Unmarshal(data, &base); err != nil {
+		return ConfigStruct{}, err
+	}
+
+	if err := validateConfigVersion(base.Version); err != nil {
+		return ConfigStruct{}, err
+	}
+
+	// Normalize legacy files in memory so every downstream consumer sees an
+	// explicit, supported version.
+	base.Version = currentConfigVersion
+	return base, nil
+}
+
+func validateConfigVersion(configVersion int) error {
+	if configVersion != currentConfigVersion {
+		return fmt.Errorf(
+			"this CLI does not support config version %d (supported version: %d)",
+			configVersion,
+			currentConfigVersion,
+		)
 	}
 
 	return nil

--- a/config/configStruct.go
+++ b/config/configStruct.go
@@ -12,10 +12,19 @@ import (
 
 const (
 	KubeConfigPathConfigName = "kube-configPath"
+
+	// initialConfigVersion is the implicit version of files written before the
+	// schema gained an explicit version field.
+	initialConfigVersion = 1
+
+	// currentConfigVersion identifies the schema written by this CLI. Increment it
+	// only when an older configuration can no longer be loaded safely.
+	currentConfigVersion = initialConfigVersion
 )
 
 func CreateDefaultConfig() ConfigStruct {
 	return ConfigStruct{
+		Version: currentConfigVersion,
 		Tap: configStructs.TapConfig{
 			NodeSelectorTerms: configStructs.NodeSelectorTermsConfig{
 				Workers: []v1.NodeSelectorTerm{
@@ -167,6 +176,7 @@ type ManifestsConfig struct {
 }
 
 type ConfigStruct struct {
+	Version              int                           `yaml:"version" json:"version"`
 	Tap                  configStructs.TapConfig       `yaml:"tap" json:"tap"`
 	Logs                 configStructs.LogsConfig      `yaml:"logs" json:"logs"`
 	Config               configStructs.ConfigConfig    `yaml:"config,omitempty" json:"config,omitempty"`

--- a/config/config_version_test.go
+++ b/config/config_version_test.go
@@ -1,0 +1,303 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kubeshark/kubeshark/config/configStructs"
+)
+
+func TestValidateConfigVersion(t *testing.T) {
+	tests := []struct {
+		name          string
+		version       int
+		wantErrSubstr string
+	}{
+		{
+			name:    "current version",
+			version: currentConfigVersion,
+		},
+		{
+			name:          "older version",
+			version:       0,
+			wantErrSubstr: "this CLI does not support config version",
+		},
+		{
+			name:          "newer version",
+			version:       currentConfigVersion + 1,
+			wantErrSubstr: "this CLI does not support config version",
+		},
+		{
+			name:          "negative version",
+			version:       -1,
+			wantErrSubstr: "this CLI does not support config version",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertError(t, validateConfigVersion(test.version), test.wantErrSubstr)
+		})
+	}
+}
+
+func TestConfigConstructorsUseCurrentVersion(t *testing.T) {
+	if got := CreateDefaultConfig().Version; got != currentConfigVersion {
+		t.Fatalf("CreateDefaultConfig().Version = %d, want %d", got, currentConfigVersion)
+	}
+
+	config, err := GetConfigWithDefaults()
+	if err != nil {
+		t.Fatalf("GetConfigWithDefaults() error: %v", err)
+	}
+	if config.Version != currentConfigVersion {
+		t.Fatalf("GetConfigWithDefaults().Version = %d, want %d", config.Version, currentConfigVersion)
+	}
+}
+
+func TestWriteConfigUsesCurrentVersion(t *testing.T) {
+	setConfigFilePathForTest(t, filepath.Join(t.TempDir(), "config.yaml"))
+
+	config := ConfigStruct{Version: currentConfigVersion + 1}
+	if err := WriteConfig(&config); err != nil {
+		t.Fatalf("WriteConfig() error: %v", err)
+	}
+
+	data, err := os.ReadFile(ConfigFilePath)
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	if !strings.HasPrefix(string(data), fmt.Sprintf("version: %d\n", currentConfigVersion)) {
+		t.Fatalf("written config does not start with current version:\n%s", data)
+	}
+	if config.Version != currentConfigVersion+1 {
+		t.Fatalf("WriteConfig() mutated its input version: got %d", config.Version)
+	}
+}
+
+func TestHelmValuesUseCurrentConfigVersion(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "helm-chart", "values.yaml"))
+	if err != nil {
+		t.Fatalf("ReadFile() error: %v", err)
+	}
+	if _, err := decodeConfig(data, ConfigStruct{}); err != nil {
+		t.Fatalf("helm values config version is out of sync: %v", err)
+	}
+}
+
+func TestLoadConfigFile(t *testing.T) {
+	tests := []struct {
+		name          string
+		data          string
+		wantErrSubstr string
+		wantLogLevel  string
+	}{
+		{
+			name:         "legacy file",
+			data:         "logLevel: debug\n",
+			wantLogLevel: "debug",
+		},
+		{
+			name:         "current file",
+			data:         fmt.Sprintf("version: %d\nlogLevel: debug\n", currentConfigVersion),
+			wantLogLevel: "debug",
+		},
+		{
+			name:          "incompatible file",
+			data:          fmt.Sprintf("version: %d\nlogLevel: debug\n", currentConfigVersion+1),
+			wantErrSubstr: "this CLI does not support config version",
+			wantLogLevel:  "warning",
+		},
+		{
+			name:          "non-integer version",
+			data:          "version: invalid\nlogLevel: debug\n",
+			wantErrSubstr: "cannot unmarshal",
+			wantLogLevel:  "warning",
+		},
+		{
+			name:          "malformed file",
+			data:          "version: [\nlogLevel: debug\n",
+			wantErrSubstr: "cannot unmarshal",
+			wantLogLevel:  "warning",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setConfigFilePathForTest(t, filepath.Join(t.TempDir(), "config.yaml"))
+			if err := os.WriteFile(ConfigFilePath, []byte(test.data), 0o600); err != nil {
+				t.Fatalf("WriteFile() error: %v", err)
+			}
+
+			loaded := ConfigStruct{Version: currentConfigVersion, LogLevel: "warning"}
+			beforeLoad := loaded
+			err := loadConfigFile(&loaded, true)
+			assertError(t, err, test.wantErrSubstr)
+			if test.wantErrSubstr == "" {
+				if loaded.Version != currentConfigVersion {
+					t.Fatalf("loaded version = %d, want %d", loaded.Version, currentConfigVersion)
+				}
+			} else {
+				if !reflect.DeepEqual(loaded, beforeLoad) {
+					t.Fatalf("loadConfigFile() changed config after an error: got %#v, want %#v", loaded, beforeLoad)
+				}
+			}
+
+			if loaded.LogLevel != test.wantLogLevel {
+				t.Fatalf("loaded log level = %q, want %q", loaded.LogLevel, test.wantLogLevel)
+			}
+		})
+	}
+}
+
+func TestLoadConfigFileForCommand(t *testing.T) {
+	tests := []struct {
+		name          string
+		command       func(*testing.T) *cobra.Command
+		data          string
+		wantErrSubstr string
+		wantLogLevel  string
+	}{
+		{
+			name: "ordinary command loads config",
+			command: func(*testing.T) *cobra.Command {
+				return &cobra.Command{Use: "tap"}
+			},
+			data:         "logLevel: debug\n",
+			wantLogLevel: "debug",
+		},
+		{
+			name: "config output loads config",
+			command: func(t *testing.T) *cobra.Command {
+				return newConfigCommandForTest(t, false)
+			},
+			data:         "logLevel: debug\n",
+			wantLogLevel: "debug",
+		},
+		{
+			name: "regeneration bypasses malformed config",
+			command: func(t *testing.T) *cobra.Command {
+				return newConfigCommandForTest(t, true)
+			},
+			data:         "version: [\n",
+			wantLogLevel: "warning",
+		},
+		{
+			name: "regeneration bypasses incompatible config",
+			command: func(t *testing.T) *cobra.Command {
+				return newConfigCommandForTest(t, true)
+			},
+			data:         fmt.Sprintf("version: %d\nlogLevel: debug\n", currentConfigVersion+1),
+			wantLogLevel: "warning",
+		},
+		{
+			name: "config command requires regeneration flag",
+			command: func(*testing.T) *cobra.Command {
+				return &cobra.Command{Use: "config"}
+			},
+			data:          "logLevel: debug\n",
+			wantErrSubstr: "failed reading --regenerate flag",
+			wantLogLevel:  "warning",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			setConfigFilePathForTest(t, filepath.Join(t.TempDir(), "config.yaml"))
+			if err := os.WriteFile(ConfigFilePath, []byte(test.data), 0o600); err != nil {
+				t.Fatalf("WriteFile() error: %v", err)
+			}
+
+			loaded := ConfigStruct{LogLevel: "warning"}
+			assertError(t, loadConfigFileForCommand(&loaded, test.command(t), true), test.wantErrSubstr)
+
+			if loaded.LogLevel != test.wantLogLevel {
+				t.Fatalf("loaded log level = %q, want %q", loaded.LogLevel, test.wantLogLevel)
+			}
+		})
+	}
+}
+
+func TestInitConfigReportsIncompatibleVersion(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	data := fmt.Sprintf("version: %d\n", currentConfigVersion+1)
+	if err := os.WriteFile(configPath, []byte(data), 0o600); err != nil {
+		t.Fatalf("WriteFile() error: %v", err)
+	}
+
+	originalConfig := Config
+	originalDebugMode := DebugMode
+	originalCommandName := cmdName
+	originalPath := ConfigFilePath
+	t.Cleanup(func() {
+		Config = originalConfig
+		DebugMode = originalDebugMode
+		cmdName = originalCommandName
+		ConfigFilePath = originalPath
+	})
+
+	cmd := &cobra.Command{Use: "license"}
+	cmd.Flags().Bool(DebugFlag, false, "")
+	cmd.Flags().String(ConfigPathFlag, configPath, "")
+
+	err := InitConfig(cmd)
+	if err == nil {
+		t.Fatal("InitConfig() expected an incompatibility error")
+	}
+	for _, expected := range []string{
+		"this CLI does not support config version",
+		"kubeshark config -r",
+	} {
+		if !strings.Contains(err.Error(), expected) {
+			t.Fatalf("InitConfig() error = %q, want %q", err, expected)
+		}
+	}
+}
+
+func newConfigCommandForTest(t *testing.T, regenerate bool) *cobra.Command {
+	t.Helper()
+
+	cmd := &cobra.Command{Use: "config"}
+	cmd.Flags().Bool(configStructs.RegenerateConfigName, false, "")
+	if regenerate {
+		if err := cmd.Flags().Set(configStructs.RegenerateConfigName, "true"); err != nil {
+			t.Fatalf("Set(%q) error: %v", configStructs.RegenerateConfigName, err)
+		}
+	}
+
+	return cmd
+}
+
+func setConfigFilePathForTest(t *testing.T, path string) {
+	t.Helper()
+
+	originalPath := ConfigFilePath
+	ConfigFilePath = path
+	t.Cleanup(func() {
+		ConfigFilePath = originalPath
+	})
+}
+
+func assertError(t *testing.T, err error, wantSubstring string) {
+	t.Helper()
+
+	if wantSubstring == "" {
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		return
+	}
+
+	if err == nil {
+		t.Fatalf("expected an error containing %q", wantSubstring)
+	}
+	if !strings.Contains(err.Error(), wantSubstring) {
+		t.Fatalf("error = %q, want substring %q", err, wantSubstring)
+	}
+}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -1,3 +1,4 @@
+version: 1
 tap:
   docker:
     registry: docker.io/kubeshark


### PR DESCRIPTION
## Summary

- add an explicit configuration schema version independent of the Kubeshark release version
- accept unversioned legacy files as schema v1 and reject older, newer, or malformed configurations with regeneration guidance
- decode into a temporary copy so validation is atomic and each file is parsed only once
- allow `kubeshark config -r` to replace malformed or incompatible configuration without loading it first
- keep Helm values synchronized and document compatibility and schema-evolution rules
- add table-driven coverage for validators, constructors, writing, loading, regeneration, Helm values, and CLI errors

## Testing

- `go test ./config`
- `go test ./...`
- `go vet ./...`
- `go test ./config -cover` — 76.4%

Closes #1378