### PR TITLE
cmd: iterate MCP path segments with SplitSeq

### DIFF
--- a/cmd/mcpRunner.go
+++ b/cmd/mcpRunner.go
@@ -944,7 +944,7 @@ func (s *mcpServer) callDownloadFile(args map[string]any) (string, bool) {
 // hasDotDotSegment reports whether p contains a ".." path segment. Used to
 // reject traversal in the caller-supplied Hub 'path' (CWE-22).
 func hasDotDotSegment(p string) bool {
-	for _, seg := range strings.Split(p, "/") {
+	for seg := range strings.SplitSeq(p, "/") {
 		if seg == ".." {
 			return true
 		}

--- a/errormessage/errormessage.go
+++ b/errormessage/errormessage.go
@@ -13,7 +13,7 @@ import (
 )
 
 // FormatError wraps error with a detailed message that is meant for the user.
-// While the errors are meant to be displayed, they are not meant to be exported as classes outsite of CLI.
+// While the errors are meant to be displayed, they are not meant to be exported as classes outside of CLI.
 func FormatError(err error) error {
 	var errorNew error
 	if k8serrors.IsForbidden(err) {


### PR DESCRIPTION
Use `strings.SplitSeq` while walking MCP resource path segments.

The code consumes each segment once and does not need the materialized slice returned by `strings.Split`, so the iterator form avoids an unnecessary allocation without changing path handling.

strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

`go test ./cmd` was run locally. The package compiled, but unrelated tests require a local kubeconfig and assume identical `/var` and `/private/var` temporary paths on macOS.

More info: https://github.com/golang/go/issues/61901